### PR TITLE
fix(ci): fix webapp peer dependency conflicts in docker build

### DIFF
--- a/webapp/.npmrc
+++ b/webapp/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/webapp/platform/docker/Dockerfile
+++ b/webapp/platform/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json package-lock.json* ./
+COPY package.json package-lock.json* .npmrc* ./
 RUN npm ci
 
 


### PR DESCRIPTION
This PR adds .npmrc with legacy-peer-deps=true to the webapp, and updates the Dockerfile to copy .npmrc, ensuring that graphql 17 can be resolved with graphql-request in Docker builds.