### PR TITLE
Security: harden preview lifecycle and credential handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,20 +344,82 @@ jobs:
             python3 .circleci/scripts/clone_preview_secrets.py "$CIRCLE_BRANCH"
       - run:
           name: Wait for Deployment Readiness
-          no_output_timeout: 10m
+          no_output_timeout: 1m
           command: |
             SANITIZED_BRANCH=$(python3 .circleci/scripts/sanitise_branch.py "$CIRCLE_BRANCH")
             TARGET_NAMESPACE="nutrition-staging--${SANITIZED_BRANCH}"
             KUSTOMIZATION_NAME="nutrition-preview-${SANITIZED_BRANCH}"
-            
+            TIMEOUT_SECONDS=600
+            CHECK_INTERVAL_SECONDS=10
+            DEADLINE=$(( $(date +%s) + TIMEOUT_SECONDS ))
+            set -euo pipefail
+
+            log_deploy_diagnostics() {
+              local deployment="$1"
+
+              echo "Deployment diagnostics for ${deployment}:"
+              kubectl describe deployment "${deployment}" -n "${TARGET_NAMESPACE}" || true
+              kubectl get deployment "${deployment}" -n "${TARGET_NAMESPACE}" -o wide || true
+            }
+
+            log_kustomization_diagnostics() {
+              echo "Kustomization diagnostics:"
+              kubectl describe kustomization "${KUSTOMIZATION_NAME}" -n flux-system || true
+              kubectl get kustomization "${KUSTOMIZATION_NAME}" -n flux-system -o wide || true
+              kubectl get pods -n "${TARGET_NAMESPACE}" -o wide || true
+              kubectl describe pods -n "${TARGET_NAMESPACE}" --all-containers=true || true
+            }
+
+            echo "Triggering reconciliation for ${KUSTOMIZATION_NAME}..."
+            kubectl annotate kustomization "${KUSTOMIZATION_NAME}" -n flux-system \
+              reconcile.fluxcd.io/requestedAt="$(date +%s)" --overwrite
+
             echo "Waiting for Flux Kustomization..."
-            kubectl wait --for=condition=ready kustomization/${KUSTOMIZATION_NAME} -n flux-system --timeout=600s
-            
-            echo "Checking backend rollout status..."
-            kubectl rollout status deployment/nutrition-backend -n ${TARGET_NAMESPACE} --timeout=600s
-            
-            echo "Checking webapp rollout status..."
-            kubectl rollout status deployment/nutrition-webapp -n ${TARGET_NAMESPACE} --timeout=600s
+            while :; do
+              remaining=$((DEADLINE - $(date +%s)))
+              if [ "$remaining" -le 0 ]; then
+                echo "Timed out waiting for Flux Kustomization ${KUSTOMIZATION_NAME}."
+                log_kustomization_diagnostics
+                exit 1
+              fi
+
+              ready_status="$(kubectl get kustomization "${KUSTOMIZATION_NAME}" -n flux-system \
+                -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' || true)"
+              echo "Kustomization ready status: ${ready_status:-<unknown>}; remaining=${remaining}s"
+
+              if [ "$ready_status" = "True" ]; then
+                echo "Flux Kustomization is ready."
+                break
+              fi
+
+              kubectl get deployment nutrition-backend nutrition-webapp -n "${TARGET_NAMESPACE}" -o wide || true
+              sleep "$CHECK_INTERVAL_SECONDS"
+            done
+
+            for deployment in nutrition-backend nutrition-webapp; do
+              echo "Checking ${deployment} rollout status..."
+              while :; do
+                remaining=$((DEADLINE - $(date +%s)))
+                if [ "$remaining" -le 0 ]; then
+                  echo "Timed out waiting for rollout of ${deployment} in ${TARGET_NAMESPACE}."
+                  log_kustomization_diagnostics
+                  log_deploy_diagnostics "${deployment}"
+                  kubectl get events -n "${TARGET_NAMESPACE}" \
+                    --field-selector involvedObject.name="${deployment}",involvedObject.kind=Deployment \
+                    --sort-by=.metadata.creationTimestamp | tail -n 25 || true
+                  exit 1
+                fi
+
+                if kubectl rollout status "deployment/${deployment}" -n "${TARGET_NAMESPACE}" --timeout=15s; then
+                  echo "${deployment} rollout complete."
+                  break
+                fi
+
+                echo "Waiting for ${deployment} rollout... remaining=${remaining}s"
+                kubectl get pods -n "${TARGET_NAMESPACE}" -l "app.kubernetes.io/name=${deployment#nutrition-}" -o wide || true
+                sleep "$CHECK_INTERVAL_SECONDS"
+              done
+            done
 
   deploy-staging:
     working_directory: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ jobs:
               kubectl describe kustomization "${KUSTOMIZATION_NAME}" -n flux-system || true
               kubectl get kustomization "${KUSTOMIZATION_NAME}" -n flux-system -o wide || true
               kubectl get pods -n "${TARGET_NAMESPACE}" -o wide || true
-              kubectl describe pods -n "${TARGET_NAMESPACE}" --all-containers=true || true
+              kubectl describe pods -n "${TARGET_NAMESPACE}" || true
             }
 
             echo "Triggering reconciliation for ${KUSTOMIZATION_NAME}..."

--- a/.circleci/dependency-audit-npm-allowlist.txt
+++ b/.circleci/dependency-audit-npm-allowlist.txt
@@ -1,3 +1,12 @@
 # Temporary vulnerability waivers (frontend, production audit gate).
 # Add one vulnerability ID per line (GHSA-xxxx-... or CVE-xxxx-xxxx)
 # Include owner and removal date in the PR description before merging.
+
+# GHSA-5p4m-2wfm-xmqj: js-yaml quadratic CPU in !!omap resolution (3.x/4.x).
+#   No patched release for the pinned major yet. Owner: OpenClawFeexBot.
+#   Review/remove by 2026-08-21.
+GHSA-5p4m-2wfm-xmqj
+# GHSA-2v37-7h3g-55p8: nanoid custom generators can loop indefinitely with
+#   size=0. Depends on upstream fix. Owner: OpenClawFeexBot.
+#   Review/remove by 2026-08-21.
+GHSA-2v37-7h3g-55p8

--- a/.circleci/dependency-audit-npm-allowlist.txt
+++ b/.circleci/dependency-audit-npm-allowlist.txt
@@ -1,12 +1,3 @@
 # Temporary vulnerability waivers (frontend, production audit gate).
 # Add one vulnerability ID per line (GHSA-xxxx-... or CVE-xxxx-xxxx)
 # Include owner and removal date in the PR description before merging.
-
-# GHSA-5p4m-2wfm-xmqj: js-yaml quadratic CPU in !!omap resolution (3.x/4.x).
-#   No patched release for the pinned major yet. Owner: OpenClawFeexBot.
-#   Review/remove by 2026-08-21.
-GHSA-5p4m-2wfm-xmqj
-# GHSA-2v37-7h3g-55p8: nanoid custom generators can loop indefinitely with
-#   size=0. Depends on upstream fix. Owner: OpenClawFeexBot.
-#   Review/remove by 2026-08-21.
-GHSA-2v37-7h3g-55p8

--- a/.circleci/scripts/cleanup_flux_preview.py
+++ b/.circleci/scripts/cleanup_flux_preview.py
@@ -2,9 +2,143 @@
 
 import subprocess  # nosec: B404
 import sys
+import time
+from dataclasses import dataclass
 
 import click
 from sanitise_branch import sanitise_branch_name
+
+
+KUSTOMIZATION_PREFIX = "nutrition-preview-"
+GIT_REPO_PREFIX = "source-"
+NAMESPACE_PREFIX = "nutrition-staging--"
+SERVICE_ACCOUNT_PREFIX = "nutrition-preview-sa"
+
+VERIFICATION_TIMEOUT_SECONDS = 120
+VERIFICATION_POLL_SECONDS = 3
+
+
+@dataclass(frozen=True)
+class DeletableResource:
+    kind: str
+    namespace: str | None
+    name: str
+
+    def delete_cmd(self) -> list[str]:
+        cmd = ["kubectl", "delete", self.kind, self.name]
+        if self.namespace:
+            cmd.extend(["-n", self.namespace])
+        cmd.append("--ignore-not-found")
+        return cmd
+
+    def exists_cmd(self) -> list[str]:
+        cmd = ["kubectl", "get", self.kind, self.name]
+        if self.namespace:
+            cmd.extend(["-n", self.namespace])
+        return cmd
+
+
+def _preview_kustomization_name(sanitized_branch: str) -> str:
+    return f"{KUSTOMIZATION_PREFIX}{sanitized_branch}"
+
+
+def _preview_git_repo_name(sanitized_branch: str) -> str:
+    return f"{GIT_REPO_PREFIX}{sanitized_branch}"
+
+
+def _preview_namespace_name(sanitized_branch: str) -> str:
+    return f"{NAMESPACE_PREFIX}{sanitized_branch}"
+
+
+def _preview_service_account_name(sanitized_branch: str) -> str:
+    return f"{SERVICE_ACCOUNT_PREFIX}-{sanitized_branch}"
+
+
+def _iter_resources(sanitized_branch: str) -> list[DeletableResource]:
+    namespace = _preview_namespace_name(sanitized_branch)
+    return [
+        DeletableResource(
+            "kustomization", "flux-system", _preview_kustomization_name(sanitized_branch)
+        ),
+        DeletableResource("gitrepository", "flux-system", _preview_git_repo_name(sanitized_branch)),
+        DeletableResource(
+            "serviceaccount", "flux-system", _preview_service_account_name(sanitized_branch)
+        ),
+        DeletableResource("namespace", None, namespace),
+    ]
+
+
+def _delete_resources(resources: list[DeletableResource]) -> tuple[bool, str]:
+    for resource in resources:
+        command = resource.delete_cmd()
+        click.echo(f"Executing: {' '.join(command)}")
+        try:
+            result = subprocess.run(  # nosec: B603, B607
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as exc:  # pragma: no cover - integration failure path
+            return (
+                False,
+                f"Error deleting {resource.kind} '{resource.name}': {exc}",
+            )
+
+        if result.returncode != 0:
+            message = (result.stderr or result.stdout or "unknown error").strip()
+            return (
+                False,
+                (
+                    f"Failed to delete {resource.kind} '{resource.name}' in "
+                    f"namespace '{resource.namespace or 'cluster'}': {message}"
+                ),
+            )
+    return True, ""
+
+
+def _resource_exists(resource: DeletableResource) -> tuple[bool, str]:
+    result = subprocess.run(  # nosec: B603, B607
+        resource.exists_cmd(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if result.returncode == 0:
+        return True, ""
+
+    message = (result.stdout + result.stderr).lower()
+    if "not found" in message:
+        return False, ""
+
+    return (
+        False,
+        f"Unable to verify deletion of {resource.kind} '{resource.name}': {(result.stderr or result.stdout or 'unknown error').strip()}",
+    )
+
+
+def _wait_for_absent(resource: DeletableResource) -> tuple[bool, str]:
+    deadline = time.time() + VERIFICATION_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        exists, msg = _resource_exists(resource)
+        if msg:
+            return False, msg
+        if not exists:
+            return True, ""
+
+        click.echo(f"Waiting for {resource.kind} '{resource.name}' to disappear...")
+        time.sleep(VERIFICATION_POLL_SECONDS)
+
+    return False, f"Timed out waiting for {resource.kind} '{resource.name}'."
+
+
+def _verify_absent(resources: list[DeletableResource]) -> tuple[bool, str]:
+    for resource in resources:
+        deleted, msg = _wait_for_absent(resource)
+        if not deleted:
+            return False, msg
+    return True, ""
 
 
 @click.command()
@@ -13,56 +147,38 @@ from sanitise_branch import sanitise_branch_name
     "--dry-run", is_flag=True, help="Print actions instead of executing"
 )
 def main(branch: str, dry_run: bool) -> None:
-    """Cleanup Flux Preview Environment (Pure Imperative).
-
-    Args:
-        branch (str): The branch name involved in the preview.
-        dry_run (bool): If True, prints commands without executing.
-    """
+    """Cleanup Flux Preview Environment (Pure Imperative)."""
     if branch == "main":
         click.echo("Branch is main. Skipping cleanup.")
         sys.exit(0)
 
     sanitized_branch = sanitise_branch_name(branch)
 
-    # Resources to clean up
-    # 1. Kustomization (nutrition-preview-*)
-    # 2. GitRepository (source-*)
-    # 3. Namespace (nutrition-staging--*)
-
-    kustomization_name = f"nutrition-preview-{sanitized_branch}"
-    gitrepo_name = f"source-{sanitized_branch}"
-    target_namespace = f"nutrition-staging--{sanitized_branch}"
-
     click.echo(
         f"Cleaning up preview environment for branch '{branch}' "
         f"(sanitized: {sanitized_branch})..."
     )
 
-    commands = [
-        (
-            f"kubectl delete kustomization {kustomization_name} "
-            "-n flux-system --ignore-not-found"
-        ),
-        (
-            f"kubectl delete gitrepository {gitrepo_name} "
-            "-n flux-system --ignore-not-found"
-        ),
-        (f"kubectl delete namespace {target_namespace} " "--ignore-not-found"),
-    ]
+    resources = _iter_resources(sanitized_branch)
 
-    for cmd in commands:
-        if dry_run:
-            click.echo(f"[Dry Run] {cmd}")
-        else:
-            click.echo(f"Executing: {cmd}")
-            try:
-                subprocess.run(cmd.split(), check=False)  # nosec: B603
-            except OSError as e:
-                click.echo(f"Error executing command: {e}", err=True)
+    if dry_run:
+        for resource in resources:
+            click.echo(f"[Dry Run] {' '.join(resource.delete_cmd())}")
+        return
 
-    if not dry_run:
-        click.echo("Cleanup sequence completed.")
+    success, error = _delete_resources(resources)
+    if not success:
+        click.echo(error, err=True)
+        click.echo("Cleanup sequence failed.", err=True)
+        sys.exit(1)
+
+    verified, verify_error = _verify_absent(resources)
+    if not verified:
+        click.echo(verify_error, err=True)
+        click.echo("Cleanup sequence failed.", err=True)
+        sys.exit(1)
+
+    click.echo("Cleanup sequence completed.")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/.circleci/scripts/cleanup_flux_preview.py
+++ b/.circleci/scripts/cleanup_flux_preview.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 import click
 from sanitise_branch import sanitise_branch_name
 
-
 KUSTOMIZATION_PREFIX = "nutrition-preview-"
 GIT_REPO_PREFIX = "source-"
 NAMESPACE_PREFIX = "nutrition-staging--"
@@ -58,11 +57,19 @@ def _iter_resources(sanitized_branch: str) -> list[DeletableResource]:
     namespace = _preview_namespace_name(sanitized_branch)
     return [
         DeletableResource(
-            "kustomization", "flux-system", _preview_kustomization_name(sanitized_branch)
+            "kustomization",
+            "flux-system",
+            _preview_kustomization_name(sanitized_branch),
         ),
-        DeletableResource("gitrepository", "flux-system", _preview_git_repo_name(sanitized_branch)),
         DeletableResource(
-            "serviceaccount", "flux-system", _preview_service_account_name(sanitized_branch)
+            "gitrepository",
+            "flux-system",
+            _preview_git_repo_name(sanitized_branch),
+        ),
+        DeletableResource(
+            "serviceaccount",
+            "flux-system",
+            _preview_service_account_name(sanitized_branch),
         ),
         DeletableResource("namespace", None, namespace),
     ]
@@ -86,7 +93,9 @@ def _delete_resources(resources: list[DeletableResource]) -> tuple[bool, str]:
             )
 
         if result.returncode != 0:
-            message = (result.stderr or result.stdout or "unknown error").strip()
+            message = (
+                result.stderr or result.stdout or "unknown error"
+            ).strip()
             return (
                 False,
                 (
@@ -127,7 +136,9 @@ def _wait_for_absent(resource: DeletableResource) -> tuple[bool, str]:
         if not exists:
             return True, ""
 
-        click.echo(f"Waiting for {resource.kind} '{resource.name}' to disappear...")
+        click.echo(
+            f"Waiting for {resource.kind} '{resource.name}' to disappear..."
+        )
         time.sleep(VERIFICATION_POLL_SECONDS)
 
     return False, f"Timed out waiting for {resource.kind} '{resource.name}'."

--- a/.circleci/scripts/cleanup_flux_preview.py
+++ b/.circleci/scripts/cleanup_flux_preview.py
@@ -19,11 +19,18 @@ VERIFICATION_POLL_SECONDS = 3
 
 @dataclass(frozen=True)
 class DeletableResource:
+    """Represents a Kubernetes resource handled by the cleanup process."""
+
     kind: str
     namespace: str | None
     name: str
 
     def delete_cmd(self) -> list[str]:
+        """Return the kubectl command used to delete this resource.
+
+        Returns:
+            list[str]: kubectl args that delete this resource.
+        """
         cmd = ["kubectl", "delete", self.kind, self.name]
         if self.namespace:
             cmd.extend(["-n", self.namespace])
@@ -31,6 +38,11 @@ class DeletableResource:
         return cmd
 
     def exists_cmd(self) -> list[str]:
+        """Return the kubectl command used to check this resource exists.
+
+        Returns:
+            list[str]: kubectl args that check this resource exists.
+        """
         cmd = ["kubectl", "get", self.kind, self.name]
         if self.namespace:
             cmd.extend(["-n", self.namespace])
@@ -99,7 +111,8 @@ def _delete_resources(resources: list[DeletableResource]) -> tuple[bool, str]:
             return (
                 False,
                 (
-                    f"Failed to delete {resource.kind} '{resource.name}' in "
+                    "Failed to delete "
+                    f"{resource.kind} '{resource.name}' in "
                     f"namespace '{resource.namespace or 'cluster'}': {message}"
                 ),
             )
@@ -121,9 +134,10 @@ def _resource_exists(resource: DeletableResource) -> tuple[bool, str]:
     if "not found" in message:
         return False, ""
 
+    details = (result.stderr or result.stdout or "unknown error").strip()
     return (
         False,
-        f"Unable to verify deletion of {resource.kind} '{resource.name}': {(result.stderr or result.stdout or 'unknown error').strip()}",
+        f"Unable to verify deletion of {resource.kind} '{resource.name}': {details}",
     )
 
 
@@ -158,7 +172,12 @@ def _verify_absent(resources: list[DeletableResource]) -> tuple[bool, str]:
     "--dry-run", is_flag=True, help="Print actions instead of executing"
 )
 def main(branch: str, dry_run: bool) -> None:
-    """Cleanup Flux Preview Environment (Pure Imperative)."""
+    """Cleanup Flux Preview Environment (Pure Imperative).
+
+    Args:
+        branch (str): The branch being deleted.
+        dry_run (bool): Whether to print commands without executing them.
+    """
     if branch == "main":
         click.echo("Branch is main. Skipping cleanup.")
         sys.exit(0)

--- a/.circleci/scripts/clone_preview_secrets.py
+++ b/.circleci/scripts/clone_preview_secrets.py
@@ -87,7 +87,9 @@ def clone_secrets(target_namespace: str) -> None:
                     },
                 },
                 "type": "Opaque",
-                "stringData": {key: generator() for key, generator in fields.items()},
+                "stringData": {
+                    key: generator() for key, generator in fields.items()
+                },
             }
 
             subprocess.run(

--- a/.circleci/scripts/clone_preview_secrets.py
+++ b/.circleci/scripts/clone_preview_secrets.py
@@ -1,21 +1,34 @@
 """Script to clone Kubernetes secrets to preview namespaces in CI."""
 
-import json
+import secrets
 import subprocess  # nosec: B404
 import sys
 import time
+import json
 
 import click
 from sanitise_branch import sanitise_branch_name
 
-SECRETS = [
-    "nutrition-webapp-nextauth-secret",
-    "nutrition-postgresql",
-    "nutrition-django-secret-key",
-    "nutrition-gemini-api-key",
-    "nutrition-gcp-db-backup-credentials",
-]
-SOURCE_NS = "nutrition-staging"
+SECRET_SCHEMA = {
+    "nutrition-webapp-nextauth-secret": {
+        "nextauth-secret": lambda: secrets.token_urlsafe(32),
+    },
+    "nutrition-postgresql": {
+        "postgresql-password": lambda: secrets.token_urlsafe(32),
+    },
+    "nutrition-django-secret-key": {
+        "secret-key": lambda: secrets.token_urlsafe(64),
+    },
+    "nutrition-gemini-api-key": {
+        "gemini-api-key": lambda: secrets.token_urlsafe(32),
+    },
+    "nutrition-gcp-db-backup-credentials": {
+        "nutrition-gcp-db-backup-credentials.json": lambda: "{}",
+    },
+}
+NAMESPACE_PREFIX = "nutrition-staging--"
+
+TARGET_SECRET_PREFIX = "nutrition-preview"
 
 
 def wait_for_namespace(namespace: str, timeout_seconds: int = 300) -> None:
@@ -52,46 +65,33 @@ def clone_secrets(target_namespace: str) -> None:
     Args:
         target_namespace (str): The namespace to clone secrets to.
     """
-    for secret in SECRETS:
-        click.echo(
-            f"Copying {secret} from {SOURCE_NS} to {target_namespace}..."
-        )
+    for secret_name, fields in SECRET_SCHEMA.items():
+        click.echo(f"Creating least-privilege preview secret {secret_name}...")
         try:
-            res = subprocess.run(
-                [
-                    "kubectl",
-                    "get",
-                    "secret",
-                    secret,
-                    "-n",
-                    SOURCE_NS,
-                    "-o",
-                    "json",
-                ],
-                capture_output=True,
-                check=True,
-            )  # nosec: B603, B607
-            secret_data = json.loads(res.stdout)
-
-            metadata = secret_data.get("metadata", {})
-            for key in [
-                "namespace",
-                "resourceVersion",
-                "uid",
-                "creationTimestamp",
-                "ownerReferences",
-            ]:
-                metadata.pop(key, None)
+            secret_data = {
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {
+                    "name": secret_name,
+                    "namespace": target_namespace,
+                    "labels": {
+                        "app.kubernetes.io/managed-by": TARGET_SECRET_PREFIX,
+                    },
+                },
+                "type": "Opaque",
+                "stringData": {
+                    key: generator() for key, generator in fields.items()
+                },
+            }
 
             subprocess.run(
                 ["kubectl", "apply", "-n", target_namespace, "-f", "-"],
                 input=json.dumps(secret_data).encode("utf-8"),
                 check=True,
             )  # nosec: B603, B607
-
-        except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        except (OSError, subprocess.CalledProcessError) as e:
             click.echo(
-                f"Error cloning secret {secret}: {e}",
+                f"Error creating secret {secret_name}: {e}",
                 err=True,
             )
             sys.exit(1)
@@ -111,6 +111,12 @@ def main(branch: str) -> None:
 
     sanitized_branch = sanitise_branch_name(branch)
     target_namespace = f"nutrition-staging--{sanitized_branch}"
+    if not target_namespace.startswith(NAMESPACE_PREFIX):
+        click.echo(
+            f"ERROR: Invalid target namespace '{target_namespace}'.",
+            err=True,
+        )
+        sys.exit(1)
 
     wait_for_namespace(target_namespace)
     clone_secrets(target_namespace)

--- a/.circleci/scripts/clone_preview_secrets.py
+++ b/.circleci/scripts/clone_preview_secrets.py
@@ -66,6 +66,14 @@ def clone_secrets(target_namespace: str) -> None:
         target_namespace (str): The namespace to clone secrets to.
     """
     for secret_name, fields in SECRET_SCHEMA.items():
+        exists = subprocess.run(
+            ["kubectl", "get", "secret", secret_name, "-n", target_namespace],
+            capture_output=True,
+            check=False,
+        )  # nosec: B603, B607
+        if exists.returncode == 0:
+            click.echo(f"Secret {secret_name} already exists. Skipping.")
+            continue
         click.echo(f"Creating least-privilege preview secret {secret_name}...")
         try:
             secret_data = {
@@ -79,9 +87,7 @@ def clone_secrets(target_namespace: str) -> None:
                     },
                 },
                 "type": "Opaque",
-                "stringData": {
-                    key: generator() for key, generator in fields.items()
-                },
+                "stringData": {key: generator() for key, generator in fields.items()},
             }
 
             subprocess.run(

--- a/.circleci/scripts/clone_preview_secrets.py
+++ b/.circleci/scripts/clone_preview_secrets.py
@@ -1,10 +1,10 @@
 """Script to generate short-lived, least-privilege preview secrets in CI."""
 
+import json
 import secrets
 import subprocess  # nosec: B404
 import sys
 import time
-import json
 
 import click
 from sanitise_branch import sanitise_branch_name
@@ -28,7 +28,7 @@ SECRET_SCHEMA = {
 }
 NAMESPACE_PREFIX = "nutrition-staging--"
 
-TARGET_SECRET_PREFIX = "nutrition-preview"
+TARGET_SECRET_PREFIX = "nutrition-preview"  # nosec: B105
 
 
 def wait_for_namespace(namespace: str, timeout_seconds: int = 300) -> None:

--- a/.circleci/scripts/clone_preview_secrets.py
+++ b/.circleci/scripts/clone_preview_secrets.py
@@ -1,4 +1,4 @@
-"""Script to clone Kubernetes secrets to preview namespaces in CI."""
+"""Script to generate short-lived, least-privilege preview secrets in CI."""
 
 import secrets
 import subprocess  # nosec: B404
@@ -60,7 +60,7 @@ def wait_for_namespace(namespace: str, timeout_seconds: int = 300) -> None:
 
 
 def clone_secrets(target_namespace: str) -> None:
-    """Clone the required secrets to the target namespace.
+    """Create the required preview secrets directly in the target namespace.
 
     Args:
         target_namespace (str): The namespace to clone secrets to.

--- a/.circleci/scripts/generate_flux_preview.py
+++ b/.circleci/scripts/generate_flux_preview.py
@@ -7,6 +7,88 @@ import sys
 import click
 from sanitise_branch import sanitise_branch_name
 
+KUSTOMIZATION_PREFIX = "nutrition-preview-"
+GIT_REPO_PREFIX = "source-"
+SERVICE_ACCOUNT_PREFIX = "nutrition-preview-sa"
+ROLE_PREFIX = "nutrition-preview-rbac"
+NAMESPACE_PREFIX = "nutrition-staging--"
+TRUSTED_SOURCE_BRANCH = "main"
+
+
+def _preview_service_account_name(sanitized_branch: str) -> str:
+    return f"{SERVICE_ACCOUNT_PREFIX}-{sanitized_branch}"
+
+
+def _preview_role_name(sanitized_branch: str) -> str:
+    return f"{ROLE_PREFIX}-{sanitized_branch}"
+
+
+def _preview_namespace_name(sanitized_branch: str) -> str:
+    return f"{NAMESPACE_PREFIX}{sanitized_branch}"
+
+
+def _build_preview_rbac(namespace: str, sanitized_branch: str) -> str:
+    """Generate RBAC objects used by Flux preview reconciliation."""
+    service_account_name = _preview_service_account_name(sanitized_branch)
+    role_name = _preview_role_name(sanitized_branch)
+
+    return f"""apiVersion: v1
+kind: Namespace
+metadata:
+  name: {namespace}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {service_account_name}
+  namespace: flux-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {role_name}
+  namespace: {namespace}
+rules:
+  - apiGroups: [""]
+    resources:
+      - "*"
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups: ["*"]
+    resources:
+      - "*"
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {role_name}
+  namespace: {namespace}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {role_name}
+subjects:
+  - kind: ServiceAccount
+    name: {service_account_name}
+    namespace: flux-system
+"""
+
 
 def generate_manifest(
     branch_name: str, image_tag: str, preview_domain: str | None = None
@@ -22,8 +104,9 @@ def generate_manifest(
         tuple[str, str]: A tuple of (manifest_content, sanitized_branch_name).
     """
     sanitized_branch = sanitise_branch_name(branch_name)
-    preview_name = f"nutrition-preview-{sanitized_branch}"
-    target_namespace = f"nutrition-staging--{sanitized_branch}"
+    preview_name = f"{KUSTOMIZATION_PREFIX}{sanitized_branch}"
+    target_namespace = _preview_namespace_name(sanitized_branch)
+    service_account_name = _preview_service_account_name(sanitized_branch)
 
     # Domain Logic
     # We use Flux Variable Substitution. The domain is NOT hardcoded here.
@@ -47,12 +130,13 @@ spec:
   interval: 1m0s
   path: ./platform/k8s/overlays/staging
   prune: true
+  serviceAccountName: {service_account_name}
   wait: true
   timeout: 10m
   targetNamespace: {target_namespace}
   sourceRef:
     kind: GitRepository
-    name: source-{sanitized_branch}
+    name: {GIT_REPO_PREFIX}{sanitized_branch}
   postBuild:
     substituteFrom:
       - kind: ConfigMap
@@ -146,6 +230,10 @@ def main(branch: str, tag: str, domain: str | None, dry_run: bool) -> None:
     kustomization_content, sanitized_branch = generate_manifest(
         branch, tag, domain
     )
+    target_namespace = _preview_namespace_name(sanitized_branch)
+    rbac_content = _build_preview_rbac(target_namespace, sanitized_branch)
+    kustomization_name = f"{KUSTOMIZATION_PREFIX}{sanitized_branch}"
+    service_account_name = _preview_service_account_name(sanitized_branch)
 
     # 2. Determine Repo URL for the GitRepository source
     try:
@@ -169,19 +257,19 @@ def main(branch: str, tag: str, domain: str | None, dry_run: bool) -> None:
     git_repo_manifest = f"""apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
-  name: source-{sanitized_branch}
+  name: {GIT_REPO_PREFIX}{sanitized_branch}
   namespace: flux-system
 spec:
   interval: 1m0s
   url: {repo_url}
   ref:
-    branch: {branch}
+    branch: {TRUSTED_SOURCE_BRANCH}
   secretRef:
     name: flux-system
 """
 
     # 4. Combine Manifests
-    full_manifest = f"{git_repo_manifest}---\n{kustomization_content}"
+    full_manifest = f"{rbac_content}---\n{git_repo_manifest}---\n{kustomization_content}"
 
     if dry_run:
         click.echo("--- Dry Run: Applying the following to cluster ---")
@@ -189,7 +277,9 @@ spec:
         return
 
     # 5. Apply to Cluster via Kubectl (Imperative)
-    click.echo(f"Applying Flux resources for branch '{branch}' to cluster...")
+    click.echo(
+        f"Applying Flux resources for branch '{branch}' to cluster (preview '{sanitized_branch}')..."
+    )
     try:
         subprocess.run(  # nosec: B607, B603
             ["kubectl", "apply", "-f", "-"],
@@ -197,8 +287,10 @@ spec:
             check=True,
         )
         click.echo(
-            f"Successfully applied GitRepository 'source-{sanitized_branch}' "
-            f"and Kustomization 'nutrition-preview-{sanitized_branch}'."
+            "Successfully applied namespace, service account, "
+            f"GitRepository '{GIT_REPO_PREFIX}{sanitized_branch}' "
+            f"and Kustomization '{kustomization_name}' "
+            f"as '{service_account_name}'."
         )
     except subprocess.CalledProcessError as e:
         click.echo(f"Failed to apply manifests: {e}", err=True)

--- a/.circleci/scripts/generate_flux_preview.py
+++ b/.circleci/scripts/generate_flux_preview.py
@@ -226,7 +226,7 @@ def main(branch: str, tag: str, domain: str | None, dry_run: bool) -> None:
     """
     if branch == "main":
         click.echo(
-            "Branch is main. Skipping preview " "generation (handled by prod flow)."
+            "Branch is main. Skipping preview generation " + "(handled by prod flow)."
         )
         sys.exit(0)
 

--- a/.circleci/scripts/generate_flux_preview.py
+++ b/.circleci/scripts/generate_flux_preview.py
@@ -226,12 +226,15 @@ def main(branch: str, tag: str, domain: str | None, dry_run: bool) -> None:
     """
     if branch == "main":
         click.echo(
-            "Branch is main. Skipping preview generation " + "(handled by prod flow)."
+            "Branch is main. Skipping preview generation "
+            + "(handled by prod flow)."
         )
         sys.exit(0)
 
     # 1. Generate the Kustomization Manifest (The "Payload")
-    kustomization_content, sanitized_branch = generate_manifest(branch, tag, domain)
+    kustomization_content, sanitized_branch = generate_manifest(
+        branch, tag, domain
+    )
     target_namespace = _preview_namespace_name(sanitized_branch)
     rbac_content = _build_preview_rbac(target_namespace, sanitized_branch)
     kustomization_name = f"{KUSTOMIZATION_PREFIX}{sanitized_branch}"
@@ -251,7 +254,9 @@ def main(branch: str, tag: str, domain: str | None, dry_run: bool) -> None:
             # Convert start 'git@github.com:' -> 'ssh://git@github.com/'
             repo_url = "ssh://" + repo_url.replace(":", "/", 1)
     except subprocess.CalledProcessError:
-        repo_url = "https://github.com/LuisMunozVillarreal/nutrition"  # Fallback
+        repo_url = (
+            "https://github.com/LuisMunozVillarreal/nutrition"  # Fallback
+        )
 
     # 3. Generate the GitRepository Manifest
     git_repo_manifest = f"""apiVersion: source.toolkit.fluxcd.io/v1beta2

--- a/.circleci/scripts/generate_flux_preview.py
+++ b/.circleci/scripts/generate_flux_preview.py
@@ -269,7 +269,9 @@ spec:
 """
 
     # 4. Combine Manifests
-    full_manifest = f"{rbac_content}---\n{git_repo_manifest}---\n{kustomization_content}"
+    full_manifest = (
+        f"{rbac_content}---\n{git_repo_manifest}---\n{kustomization_content}"
+    )
 
     if dry_run:
         click.echo("--- Dry Run: Applying the following to cluster ---")

--- a/.circleci/scripts/generate_flux_preview.py
+++ b/.circleci/scripts/generate_flux_preview.py
@@ -280,7 +280,8 @@ spec:
 
     # 5. Apply to Cluster via Kubectl (Imperative)
     click.echo(
-        f"Applying Flux resources for branch '{branch}' to cluster (preview '{sanitized_branch}')..."
+        f"Applying Flux resources for branch '{branch}' to "
+        f"cluster (preview '{sanitized_branch}')..."
     )
     try:
         subprocess.run(  # nosec: B607, B603

--- a/.circleci/scripts/generate_flux_preview.py
+++ b/.circleci/scripts/generate_flux_preview.py
@@ -172,19 +172,8 @@ spec:
                       value: "{preview_host}"
                     - name: CSRF_TRUSTED_ORIGINS
                       value: "https://{preview_host}"
-      target:
-        kind: Deployment
-        name: nutrition-backend
-    - patch: |
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: nutrition-backend
-        spec:
-          template:
-            spec:
-              containers:
-                - name: backend
+              initContainers:
+                - name: db-restore
                   env:
                     - name: SKIP_DB_RESTORE
                       value: "true"
@@ -237,15 +226,12 @@ def main(branch: str, tag: str, domain: str | None, dry_run: bool) -> None:
     """
     if branch == "main":
         click.echo(
-            "Branch is main. Skipping preview "
-            "generation (handled by prod flow)."
+            "Branch is main. Skipping preview " "generation (handled by prod flow)."
         )
         sys.exit(0)
 
     # 1. Generate the Kustomization Manifest (The "Payload")
-    kustomization_content, sanitized_branch = generate_manifest(
-        branch, tag, domain
-    )
+    kustomization_content, sanitized_branch = generate_manifest(branch, tag, domain)
     target_namespace = _preview_namespace_name(sanitized_branch)
     rbac_content = _build_preview_rbac(target_namespace, sanitized_branch)
     kustomization_name = f"{KUSTOMIZATION_PREFIX}{sanitized_branch}"
@@ -265,9 +251,7 @@ def main(branch: str, tag: str, domain: str | None, dry_run: bool) -> None:
             # Convert start 'git@github.com:' -> 'ssh://git@github.com/'
             repo_url = "ssh://" + repo_url.replace(":", "/", 1)
     except subprocess.CalledProcessError:
-        repo_url = (
-            "https://github.com/LuisMunozVillarreal/nutrition"  # Fallback
-        )
+        repo_url = "https://github.com/LuisMunozVillarreal/nutrition"  # Fallback
 
     # 3. Generate the GitRepository Manifest
     git_repo_manifest = f"""apiVersion: source.toolkit.fluxcd.io/v1beta2

--- a/.circleci/scripts/generate_flux_preview.py
+++ b/.circleci/scripts/generate_flux_preview.py
@@ -179,6 +179,22 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         metadata:
+          name: nutrition-backend
+        spec:
+          template:
+            spec:
+              containers:
+                - name: backend
+                  env:
+                    - name: SKIP_DB_RESTORE
+                      value: "true"
+      target:
+        kind: Deployment
+        name: nutrition-backend
+    - patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
           name: nutrition-webapp
         spec:
           template:

--- a/.circleci/scripts/sanitise_branch.py
+++ b/.circleci/scripts/sanitise_branch.py
@@ -10,8 +10,7 @@ DNS_LABEL_RE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
 
 
 def _normalize_branch_name(branch_name: str) -> str:
-    """
-    Normalize Git branch names to lowercase DNS-label safe characters.
+    """Normalize Git branch names to lowercase DNS-label safe characters.
 
     Replaces invalid characters with '-' and collapses consecutive separators.
     """
@@ -45,6 +44,9 @@ def sanitise_branch_name(branch_name: str) -> str:
 
     Returns:
         str: A sanitized string safe for K8s resource names.
+
+    Raises:
+        ValueError: If the normalised and hashed name is not a valid DNS label.
     """
     normalised = _normalize_branch_name(branch_name)
     sanitized = _append_stable_hash(normalised, branch_name)

--- a/.circleci/scripts/sanitise_branch.py
+++ b/.circleci/scripts/sanitise_branch.py
@@ -1,13 +1,40 @@
 """Common utilities for CircleCI scripts."""
 
 import hashlib
+import re
 import sys
 
-# Max length for the branch part is 34 characters to strictly fit
-# within the 64 char SSL CN limit. The CN format is:
-# staging--<sanitized_branch>.<BASE_DOMAIN>
-# 64 - 9 (staging--) - 1 (.) - 20 (~BASE_DOMAIN) = 34
 MAX_LENGTH = 34
+HASH_LENGTH = 7
+DNS_LABEL_RE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+
+
+def _normalize_branch_name(branch_name: str) -> str:
+    """
+    Normalize Git branch names to lowercase DNS-label safe characters.
+
+    Replaces invalid characters with '-' and collapses consecutive separators.
+    """
+    normalized = re.sub(r"[^a-z0-9-]", "-", branch_name.lower())
+    normalized = re.sub(r"-+", "-", normalized).strip("-")
+    if not normalized:
+        normalized = "branch"
+    return normalized
+
+
+def _append_stable_hash(normalized_branch: str, branch_name: str) -> str:
+    """Append a stable hash to a normalized branch identifier."""
+    branch_hash = hashlib.sha1(
+        branch_name.encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:HASH_LENGTH]
+    suffix = f"-{branch_hash}"
+    max_base_length = MAX_LENGTH - len(suffix)
+
+    base = normalized_branch[:max_base_length].strip("-")
+    if not base:
+        base = "branch"
+
+    return f"{base}{suffix}"
 
 
 def sanitise_branch_name(branch_name: str) -> str:
@@ -19,23 +46,13 @@ def sanitise_branch_name(branch_name: str) -> str:
     Returns:
         str: A sanitized string safe for K8s resource names.
     """
-    s = branch_name.lower()
-    s = s.replace("/", "-")
-    s = s.replace("_", "-")
-    s = s.replace(".", "-")
+    normalised = _normalize_branch_name(branch_name)
+    sanitized = _append_stable_hash(normalised, branch_name)
 
-    if len(s) > MAX_LENGTH:
-        # Create a hash of the original branch name for uniqueness
-        hasher = hashlib.sha1(
-            branch_name.encode("utf-8"), usedforsecurity=False
-        )
-        branch_hash = hasher.hexdigest()[:7]
+    if not DNS_LABEL_RE.fullmatch(sanitized):
+        raise ValueError(f"Could not normalise branch name: {branch_name}")
 
-        # Truncate to 26 chars to leave room for the hash (26 + 1 + 7 = 34)
-        s = s[:26].rstrip("-")
-        s = f"{s}-{branch_hash}"
-
-    return s
+    return sanitized
 
 
 if __name__ == "__main__":

--- a/.circleci/scripts/test_cleanup_preview.py
+++ b/.circleci/scripts/test_cleanup_preview.py
@@ -9,7 +9,9 @@ from sanitise_branch import sanitise_branch_name
 
 
 def _not_found_output() -> CompletedProcess:
-    return CompletedProcess(args=["kubectl"], returncode=1, stdout="", stderr="not found")
+    return CompletedProcess(
+        args=["kubectl"], returncode=1, stdout="", stderr="not found"
+    )
 
 
 def _success_output() -> CompletedProcess:
@@ -103,7 +105,9 @@ def test_main_retries_until_gone(mock_run, monkeypatch):
     mock_run.side_effect = outputs
 
     # Keep test execution fast even when waiting for transient existence.
-    monkeypatch.setattr("cleanup_flux_preview.time.sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "cleanup_flux_preview.time.sleep", lambda *_args, **_kwargs: None
+    )
     result = runner.invoke(main, ["feature/test"])
 
     assert result.exit_code == 0
@@ -134,6 +138,39 @@ def test_main_verification_failure(mock_run):
 
     assert result.exit_code == 1
     assert "Unable to verify deletion of" in result.output
+    assert "Cleanup sequence failed." in result.output
+
+
+def test_main_already_absent_resources_succeed(mock_run):
+    """Test cleanup succeeds when everything is already absent."""
+    runner = CliRunner()
+    mock_run.side_effect = [
+        _success_output(),
+        _success_output(),
+        _success_output(),
+        _success_output(),
+        _not_found_output(),
+        _not_found_output(),
+        _not_found_output(),
+        _not_found_output(),
+    ]
+
+    result = runner.invoke(main, ["feature/test"])
+
+    assert result.exit_code == 0
+    assert "Cleanup sequence completed." in result.output
+    assert mock_run.call_count == 8
+
+
+def test_main_delete_oserror_fails(mock_run):
+    """Test cleanup fails when kubectl delete command raises a system error."""
+    runner = CliRunner()
+    mock_run.side_effect = [OSError("kaboom")]
+
+    result = runner.invoke(main, ["feature/test"])
+
+    assert result.exit_code == 1
+    assert "Error deleting kustomization" in result.output
     assert "Cleanup sequence failed." in result.output
 
 

--- a/.circleci/scripts/test_cleanup_preview.py
+++ b/.circleci/scripts/test_cleanup_preview.py
@@ -1,8 +1,21 @@
 """Tests for the cleanup_flux_preview script."""
 
+from subprocess import CompletedProcess
+
 import pytest
-from cleanup_flux_preview import main
 from click.testing import CliRunner
+from cleanup_flux_preview import main
+from sanitise_branch import sanitise_branch_name
+
+
+def _not_found_output() -> CompletedProcess:
+    return CompletedProcess(args=["kubectl"], returncode=1, stdout="", stderr="not found")
+
+
+def _success_output() -> CompletedProcess:
+    return CompletedProcess(
+        args=["kubectl"], returncode=0, stdout="resource", stderr=""
+    )
 
 
 @pytest.fixture
@@ -13,63 +26,121 @@ def mock_run(mocker):
 
 def test_main_dry_run(mock_run):
     """Test the main function with dry-run enabled."""
-    # Given
     runner = CliRunner()
 
-    # When
     result = runner.invoke(main, ["feature/test", "--dry-run"])
+    sanitized = sanitise_branch_name("feature/test")
 
-    # Then
     assert result.exit_code == 0
     assert (
         "Cleaning up preview environment for branch 'feature/test'"
         in result.output
     )
-    assert "(sanitized: feature-test)" in result.output
+    assert f"(sanitized: {sanitized})" in result.output
     assert "[Dry Run] kubectl delete kustomization" in result.output
     assert "[Dry Run] kubectl delete gitrepository" in result.output
+    assert "[Dry Run] kubectl delete serviceaccount" in result.output
     assert "[Dry Run] kubectl delete namespace" in result.output
     mock_run.assert_not_called()
 
 
-def test_main_execution(mock_run):
-    """Test the main function execution (no dry-run)."""
-    # Given
+def test_main_execution_success(mock_run):
+    """Test successful cleanup executes deletion and verifies resources are gone."""
     runner = CliRunner()
+    # 4 delete calls then 4 get calls for verification
+    mock_run.side_effect = [
+        _success_output(),
+        _success_output(),
+        _success_output(),
+        _success_output(),
+        _not_found_output(),
+        _not_found_output(),
+        _not_found_output(),
+        _not_found_output(),
+    ]
 
-    # When
     result = runner.invoke(main, ["feature/test"])
 
-    # Then
     assert result.exit_code == 0
-    assert "Executing: kubectl delete kustomization" in result.output
     assert "Cleanup sequence completed." in result.output
-    assert mock_run.call_count == 3
+    assert mock_run.call_count == 8
 
 
-def test_main_skip_main_branch(mock_run):
-    """Test that the script skips cleanup for 'main' branch."""
-    # Given
+def test_main_partial_delete_failure(mock_run):
+    """Test that cleanup exits non-zero when delete fails."""
     runner = CliRunner()
+    failure = CompletedProcess(
+        args=["kubectl"], returncode=1, stdout="", stderr="permission denied"
+    )
+    mock_run.side_effect = [_success_output(), failure]
 
-    # When
-    result = runner.invoke(main, ["main"])
-
-    # Then
-    assert result.exit_code == 0
-    assert "Branch is main. Skipping cleanup." in result.output
-    mock_run.assert_not_called()
-
-
-def test_main_subprocess_error(mock_run):
-    """Test error handling during subprocess execution."""
-    # Given
-    mock_run.side_effect = OSError("Command failed")
-    runner = CliRunner()
-
-    # When
     result = runner.invoke(main, ["feature/fail"])
 
-    # Then
+    assert result.exit_code == 1
+    assert "Failed to delete" in result.output
+    assert "Cleanup sequence failed." in result.output
+
+
+def test_main_retries_until_gone(mock_run, monkeypatch):
+    """Test deletion verification retries transiently visible resources."""
+    runner = CliRunner()
+    # Delete calls
+    outputs = [
+        _success_output(),
+        _success_output(),
+        _success_output(),
+        _success_output(),
+    ]
+    # Kustomization remains for 2 checks, then disappears
+    outputs += [
+        _success_output(),
+        _success_output(),
+        _not_found_output(),
+    ]
+    # Remaining resources are absent
+    outputs += [_not_found_output(), _not_found_output(), _not_found_output()]
+
+    mock_run.side_effect = outputs
+
+    # Keep test execution fast even when waiting for transient existence.
+    monkeypatch.setattr("cleanup_flux_preview.time.sleep", lambda *_args, **_kwargs: None)
+    result = runner.invoke(main, ["feature/test"])
+
     assert result.exit_code == 0
-    assert "Error executing command: Command failed" in result.output
+    assert "Waiting for kustomization" in result.output
+    assert "Cleanup sequence completed." in result.output
+
+
+def test_main_verification_failure(mock_run):
+    """Test cleanup fails when resource verification cannot complete."""
+    runner = CliRunner()
+    mock_run.side_effect = [
+        _success_output(),
+        _success_output(),
+        _success_output(),
+        _success_output(),
+        CompletedProcess(
+            args=["kubectl"],
+            returncode=1,
+            stdout="",
+            stderr="unable to check resource",
+        ),
+        _not_found_output(),
+        _not_found_output(),
+        _not_found_output(),
+    ]
+
+    result = runner.invoke(main, ["feature/test"])
+
+    assert result.exit_code == 1
+    assert "Unable to verify deletion of" in result.output
+    assert "Cleanup sequence failed." in result.output
+
+
+def test_main_skip_main_branch():
+    """Test that the script skips cleanup for 'main' branch."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["main"])
+
+    assert result.exit_code == 0
+    assert "Branch is main. Skipping cleanup." in result.output

--- a/.circleci/scripts/test_cleanup_preview.py
+++ b/.circleci/scripts/test_cleanup_preview.py
@@ -3,8 +3,8 @@
 from subprocess import CompletedProcess
 
 import pytest
-from click.testing import CliRunner
 from cleanup_flux_preview import main
+from click.testing import CliRunner
 from sanitise_branch import sanitise_branch_name
 
 

--- a/.circleci/scripts/test_clone_secrets.py
+++ b/.circleci/scripts/test_clone_secrets.py
@@ -2,6 +2,7 @@
 
 import json
 from subprocess import CompletedProcess
+from typing import Any
 
 import pytest
 from click.testing import CliRunner
@@ -42,7 +43,9 @@ def test_main_success(mock_run, mocker):
     result = runner.invoke(main, ["feature/test-branch"])
 
     assert result.exit_code == 0
-    expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test-branch')}"
+    expected_ns = (
+        f"nutrition-staging--{sanitise_branch_name('feature/test-branch')}"
+    )
     assert f"Waiting for namespace {expected_ns} to exist..." in result.output
     assert (
         "Creating least-privilege preview secret nutrition-webapp-nextauth-secret..."
@@ -93,4 +96,86 @@ def test_main_apply_payload(mock_run, mocker):
         payload = json.loads(call.kwargs["input"].decode("utf-8"))
         assert payload["kind"] == "Secret"
         assert payload["type"] == "Opaque"
-        assert payload["metadata"]["labels"]["app.kubernetes.io/managed-by"] == "nutrition-preview"
+        assert (
+            payload["metadata"]["labels"]["app.kubernetes.io/managed-by"]
+            == "nutrition-preview"
+        )
+
+
+def test_main_does_not_read_staging_credentials(mock_run, mocker):
+    """Test that preview secret creation does not read source staging secrets."""
+    runner = CliRunner()
+    mocker.patch("time.sleep")
+
+    namespace_check = CompletedProcess(
+        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
+    )
+    apply_ok = CompletedProcess(
+        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
+    )
+    mock_run.side_effect = [namespace_check] + [apply_ok] * 5
+
+    result = runner.invoke(main, ["feature/test"])
+    expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test')}"
+
+    assert result.exit_code == 0
+    assert all(
+        call.args[0] == ["kubectl", "get", "namespace", expected_ns]
+        for call in mock_run.call_args_list
+        if call.args[0][:2] == ["kubectl", "get"]
+    )
+
+    non_staging_read_attempts = [
+        call.args[0]
+        for call in mock_run.call_args_list
+        if call.args[0][:2] == ["kubectl", "get"] and "-n" in call.args[0]
+    ]
+    assert not non_staging_read_attempts
+
+
+def test_main_secrets_are_preview_scoped_and_non_empty(mock_run, mocker):
+    """Test that each required preview secret uses generated values."""
+    runner = CliRunner()
+    mocker.patch("time.sleep")
+    generated_tokens = [
+        "token-1",
+        "token-2",
+        "token-3",
+        "token-4",
+    ]
+    mocker.patch(
+        "clone_preview_secrets.secrets.token_urlsafe",
+        side_effect=lambda _n: generated_tokens.pop(0),
+    )
+
+    namespace_check = CompletedProcess(
+        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
+    )
+    apply_ok = CompletedProcess(
+        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
+    )
+    mock_run.side_effect = [namespace_check] + [apply_ok] * 5
+
+    result = runner.invoke(main, ["feature/test"])
+    expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test')}"
+
+    assert result.exit_code == 0
+    apply_calls = [
+        call
+        for call in mock_run.call_args_list
+        if call.args[0][0:3] == ["kubectl", "apply", "-n"]
+        and call.args[0][3] == expected_ns
+    ]
+    assert len(apply_calls) == 5
+
+    seen_values: list[str] = []
+    for call in apply_calls:
+        payload: dict[str, Any] = json.loads(
+            call.kwargs["input"].decode("utf-8")
+        )
+        secrets_payload = payload["stringData"]
+        assert secrets_payload
+        seen_values.extend(secrets_payload.values())
+    assert sorted(seen_values) == sorted(
+        ["token-1", "token-2", "token-3", "token-4", "{}"]
+    )

--- a/.circleci/scripts/test_clone_secrets.py
+++ b/.circleci/scripts/test_clone_secrets.py
@@ -1,9 +1,11 @@
 """Tests for the clone_preview_secrets script."""
 
 import json
+from subprocess import CompletedProcess
 
 import pytest
 from click.testing import CliRunner
+from sanitise_branch import sanitise_branch_name
 from clone_preview_secrets import main
 
 
@@ -15,75 +17,80 @@ def mock_run(mocker):
 
 def test_main_skip_main_branch(mock_run):
     """Test that secret cloning is skipped on the main branch."""
-    # Given we have a CLI runner
     runner = CliRunner()
 
-    # When we run the script for the 'main' branch
     result = runner.invoke(main, ["main"])
 
-    # Then it should exit with code 0 and not run any subprocesses
     assert result.exit_code == 0
     assert "Branch is main. Skipping secret cloning." in result.output
     mock_run.assert_not_called()
 
 
 def test_main_success(mock_run, mocker):
-    """Test successful cloning of secrets."""
-    # Given we have a CLI runner and our subprocess mocks succeed
+    """Test successful preview credential creation."""
     runner = CliRunner()
-    mocker.patch("time.sleep")  # Avoid sleeping in tests
+    mocker.patch("time.sleep")
 
-    # Mock responses for kubectl get namespace, secrets, and apply
-    mock_get_ns = mocker.MagicMock()
-    mock_get_ns.returncode = 0
+    namespace_check = CompletedProcess(
+        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
+    )
+    apply_ok = CompletedProcess(
+        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
+    )
+    mock_run.side_effect = [namespace_check] + [apply_ok] * 5
 
-    mock_get_secret = mocker.MagicMock()
-    mock_get_secret.returncode = 0
-    mock_get_secret.stdout = json.dumps(
-        {
-            "apiVersion": "v1",
-            "kind": "Secret",
-            "metadata": {
-                "name": "my-secret",
-                "namespace": "nutrition-staging",
-                "uid": "1234",
-                "resourceVersion": "5678",
-                "creationTimestamp": "2026-07-05T00:00:00Z",
-            },
-            "data": {"key": "value"},
-        }
-    ).encode("utf-8")
-
-    mock_apply = mocker.MagicMock()
-    mock_apply.returncode = 0
-
-    mock_run.side_effect = [mock_get_ns] + [mock_get_secret, mock_apply] * 5
-
-    # When we run the script for a preview branch
     result = runner.invoke(main, ["feature/test-branch"])
 
-    # Then the script should succeed and wait for target namespace
     assert result.exit_code == 0
-    msg_ns = (
-        "Waiting for namespace "
-        + "nutrition-staging--feature-test-branch to exist..."
-    )
-    assert msg_ns in result.output
-    msg_exists = (
-        "Namespace nutrition-staging--" + "feature-test-branch exists."
-    )
-    assert msg_exists in result.output
-    assert "Copying nutrition-webapp-nextauth-secret" in result.output
+    expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test-branch')}"
+    assert f"Waiting for namespace {expected_ns} to exist..." in result.output
+    assert (
+        "Creating least-privilege preview secret nutrition-webapp-nextauth-secret..."
+    ) in result.output
+    assert (
+        "Creating least-privilege preview secret nutrition-postgresql..."
+    ) in result.output
+    assert (
+        "Creating least-privilege preview secret nutrition-gemini-api-key..."
+    ) in result.output
+    assert mock_run.call_count == 6
 
-    # And it should call kubectl get namespace once,
-    # plus get+apply for 5 secrets
-    # Total calls: 1 + (5 * 2) = 11 calls
-    assert mock_run.call_count == 11
+    # Secrets are created directly in the target namespace and never read from
+    # staging.
+    assert not any(
+        call.args[0][:2] == ["kubectl", "get"]
+        and call.args[0][3] == "-n"
+        and call.args[0][4] == "nutrition-staging"
+        for call in mock_run.call_args_list
+    )
 
-    # And it should remove unwanted metadata fields
-    last_apply_call = mock_run.call_args_list[-1]
-    applied_json = json.loads(last_apply_call[1]["input"].decode("utf-8"))
-    assert "namespace" not in applied_json["metadata"]
-    assert "uid" not in applied_json["metadata"]
-    assert "resourceVersion" not in applied_json["metadata"]
-    assert "creationTimestamp" not in applied_json["metadata"]
+
+def test_main_apply_payload(mock_run, mocker):
+    """Test that each generated secret contains expected preview keys."""
+    runner = CliRunner()
+    mocker.patch("time.sleep")
+
+    namespace_check = CompletedProcess(
+        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
+    )
+    apply_ok = CompletedProcess(
+        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
+    )
+    mock_run.side_effect = [namespace_check] + [apply_ok] * 5
+
+    runner.invoke(main, ["feature/test"])
+
+    expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test')}"
+    apply_calls = [
+        call
+        for call in mock_run.call_args_list
+        if call.args[0][0:3] == ["kubectl", "apply", "-n"]
+        and call.args[0][3] == expected_ns
+    ]
+    assert len(apply_calls) == 5
+
+    for call in apply_calls:
+        payload = json.loads(call.kwargs["input"].decode("utf-8"))
+        assert payload["kind"] == "Secret"
+        assert payload["type"] == "Opaque"
+        assert payload["metadata"]["labels"]["app.kubernetes.io/managed-by"] == "nutrition-preview"

--- a/.circleci/scripts/test_clone_secrets.py
+++ b/.circleci/scripts/test_clone_secrets.py
@@ -16,6 +16,14 @@ def mock_run(mocker):
     return mocker.patch("clone_preview_secrets.subprocess.run")
 
 
+def _fake_kubectl(*args, **kwargs):
+    """Return NotFound for secret existence checks so secrets get created."""
+    cmd = args[0]
+    if cmd[:3] == ["kubectl", "get", "secret"]:
+        return CompletedProcess(args=cmd, returncode=1, stdout=b"", stderr=b"")
+    return CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+
 def test_main_skip_main_branch(mock_run):
     """Test that secret cloning is skipped on the main branch."""
     runner = CliRunner()
@@ -35,17 +43,13 @@ def test_main_success(mock_run, mocker):
     namespace_check = CompletedProcess(
         args=["kubectl"], returncode=0, stdout=b"", stderr=b""
     )
-    apply_ok = CompletedProcess(
-        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
-    )
-    mock_run.side_effect = [namespace_check] + [apply_ok] * 5
+    apply_ok = CompletedProcess(args=["kubectl"], returncode=0, stdout=b"", stderr=b"")
+    mock_run.side_effect = _fake_kubectl
 
     result = runner.invoke(main, ["feature/test-branch"])
 
     assert result.exit_code == 0
-    expected_ns = (
-        f"nutrition-staging--{sanitise_branch_name('feature/test-branch')}"
-    )
+    expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test-branch')}"
     assert f"Waiting for namespace {expected_ns} to exist..." in result.output
     assert (
         "Creating least-privilege preview secret nutrition-webapp-nextauth-secret..."
@@ -56,7 +60,7 @@ def test_main_success(mock_run, mocker):
     assert (
         "Creating least-privilege preview secret nutrition-gemini-api-key..."
     ) in result.output
-    assert mock_run.call_count == 6
+    assert mock_run.call_count == 11
 
     # Secrets are created directly in the target namespace and never read from
     # staging.
@@ -76,10 +80,8 @@ def test_main_apply_payload(mock_run, mocker):
     namespace_check = CompletedProcess(
         args=["kubectl"], returncode=0, stdout=b"", stderr=b""
     )
-    apply_ok = CompletedProcess(
-        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
-    )
-    mock_run.side_effect = [namespace_check] + [apply_ok] * 5
+    apply_ok = CompletedProcess(args=["kubectl"], returncode=0, stdout=b"", stderr=b"")
+    mock_run.side_effect = _fake_kubectl
 
     runner.invoke(main, ["feature/test"])
 
@@ -110,10 +112,8 @@ def test_main_does_not_read_staging_credentials(mock_run, mocker):
     namespace_check = CompletedProcess(
         args=["kubectl"], returncode=0, stdout=b"", stderr=b""
     )
-    apply_ok = CompletedProcess(
-        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
-    )
-    mock_run.side_effect = [namespace_check] + [apply_ok] * 5
+    apply_ok = CompletedProcess(args=["kubectl"], returncode=0, stdout=b"", stderr=b"")
+    mock_run.side_effect = _fake_kubectl
 
     result = runner.invoke(main, ["feature/test"])
     expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test')}"
@@ -121,6 +121,10 @@ def test_main_does_not_read_staging_credentials(mock_run, mocker):
     assert result.exit_code == 0
     assert all(
         call.args[0] == ["kubectl", "get", "namespace", expected_ns]
+        or (
+            call.args[0][:3] == ["kubectl", "get", "secret"]
+            and call.args[0][-2:] == ["-n", expected_ns]
+        )
         for call in mock_run.call_args_list
         if call.args[0][:2] == ["kubectl", "get"]
     )
@@ -128,7 +132,9 @@ def test_main_does_not_read_staging_credentials(mock_run, mocker):
     non_staging_read_attempts = [
         call.args[0]
         for call in mock_run.call_args_list
-        if call.args[0][:2] == ["kubectl", "get"] and "-n" in call.args[0]
+        if call.args[0][:2] == ["kubectl", "get"]
+        and "-n" in call.args[0]
+        and call.args[0][-2:] != ["-n", expected_ns]
     ]
     assert not non_staging_read_attempts
 
@@ -151,10 +157,8 @@ def test_main_secrets_are_preview_scoped_and_non_empty(mock_run, mocker):
     namespace_check = CompletedProcess(
         args=["kubectl"], returncode=0, stdout=b"", stderr=b""
     )
-    apply_ok = CompletedProcess(
-        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
-    )
-    mock_run.side_effect = [namespace_check] + [apply_ok] * 5
+    apply_ok = CompletedProcess(args=["kubectl"], returncode=0, stdout=b"", stderr=b"")
+    mock_run.side_effect = _fake_kubectl
 
     result = runner.invoke(main, ["feature/test"])
     expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test')}"
@@ -170,9 +174,7 @@ def test_main_secrets_are_preview_scoped_and_non_empty(mock_run, mocker):
 
     seen_values: list[str] = []
     for call in apply_calls:
-        payload: dict[str, Any] = json.loads(
-            call.kwargs["input"].decode("utf-8")
-        )
+        payload: dict[str, Any] = json.loads(call.kwargs["input"].decode("utf-8"))
         secrets_payload = payload["stringData"]
         assert secrets_payload
         seen_values.extend(secrets_payload.values())

--- a/.circleci/scripts/test_clone_secrets.py
+++ b/.circleci/scripts/test_clone_secrets.py
@@ -6,8 +6,8 @@ from typing import Any
 
 import pytest
 from click.testing import CliRunner
-from sanitise_branch import sanitise_branch_name
 from clone_preview_secrets import main
+from sanitise_branch import sanitise_branch_name
 
 
 @pytest.fixture

--- a/.circleci/scripts/test_clone_secrets.py
+++ b/.circleci/scripts/test_clone_secrets.py
@@ -40,16 +40,14 @@ def test_main_success(mock_run, mocker):
     runner = CliRunner()
     mocker.patch("time.sleep")
 
-    namespace_check = CompletedProcess(
-        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
-    )
-    apply_ok = CompletedProcess(args=["kubectl"], returncode=0, stdout=b"", stderr=b"")
     mock_run.side_effect = _fake_kubectl
 
     result = runner.invoke(main, ["feature/test-branch"])
 
     assert result.exit_code == 0
-    expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test-branch')}"
+    expected_ns = (
+        f"nutrition-staging--{sanitise_branch_name('feature/test-branch')}"
+    )
     assert f"Waiting for namespace {expected_ns} to exist..." in result.output
     assert (
         "Creating least-privilege preview secret nutrition-webapp-nextauth-secret..."
@@ -77,10 +75,6 @@ def test_main_apply_payload(mock_run, mocker):
     runner = CliRunner()
     mocker.patch("time.sleep")
 
-    namespace_check = CompletedProcess(
-        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
-    )
-    apply_ok = CompletedProcess(args=["kubectl"], returncode=0, stdout=b"", stderr=b"")
     mock_run.side_effect = _fake_kubectl
 
     runner.invoke(main, ["feature/test"])
@@ -109,10 +103,6 @@ def test_main_does_not_read_staging_credentials(mock_run, mocker):
     runner = CliRunner()
     mocker.patch("time.sleep")
 
-    namespace_check = CompletedProcess(
-        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
-    )
-    apply_ok = CompletedProcess(args=["kubectl"], returncode=0, stdout=b"", stderr=b"")
     mock_run.side_effect = _fake_kubectl
 
     result = runner.invoke(main, ["feature/test"])
@@ -154,10 +144,6 @@ def test_main_secrets_are_preview_scoped_and_non_empty(mock_run, mocker):
         side_effect=lambda _n: generated_tokens.pop(0),
     )
 
-    namespace_check = CompletedProcess(
-        args=["kubectl"], returncode=0, stdout=b"", stderr=b""
-    )
-    apply_ok = CompletedProcess(args=["kubectl"], returncode=0, stdout=b"", stderr=b"")
     mock_run.side_effect = _fake_kubectl
 
     result = runner.invoke(main, ["feature/test"])
@@ -174,7 +160,9 @@ def test_main_secrets_are_preview_scoped_and_non_empty(mock_run, mocker):
 
     seen_values: list[str] = []
     for call in apply_calls:
-        payload: dict[str, Any] = json.loads(call.kwargs["input"].decode("utf-8"))
+        payload: dict[str, Any] = json.loads(
+            call.kwargs["input"].decode("utf-8")
+        )
         secrets_payload = payload["stringData"]
         assert secrets_payload
         seen_values.extend(secrets_payload.values())

--- a/.circleci/scripts/test_generate_preview.py
+++ b/.circleci/scripts/test_generate_preview.py
@@ -5,7 +5,7 @@ import subprocess
 import pytest
 from click.testing import CliRunner
 from generate_flux_preview import generate_manifest, main
-from sanitise_branch import sanitise_branch_name
+from sanitise_branch import MAX_LENGTH, sanitise_branch_name
 
 
 @pytest.fixture
@@ -21,146 +21,143 @@ def mock_run(mocker):
 
 
 def test_sanitize_branch():
-    """Test branch name sanitization logic."""
-    # Given
+    """Test branch sanitization produces deterministic and collision-resistant values."""
     branches = [
-        ("feature/new-ui", "feature-new-ui"),
-        ("JIRA_123", "jira-123"),
-        ("simple", "simple"),
-        # Boundary condition: exactly 34 chars
-        ("a" * 34, "a" * 34),
-        # Over 34 chars: 35 chars -> truncated to 26 + hash
-        (
-            "a" * 35,
-            "aaaaaaaaaaaaaaaaaaaaaaaaaa-f4d3e05",
-        ),
-        # Over 34 chars with hyphen at result cut
-        (
-            "feature/very/long/branch/name/that/exceeds/limit",
-            "feature-very-long-branch-n-c8906af",
-        ),
-        (
-            "dependabot/uv/backend/urllib3-2.6.3",
-            "dependabot-uv-backend-urll-ed362e9",
-        ),
+        "feature/new-ui",
+        "feature/new/ui",
+        "feature/new_ui",
+        "JIRA_123",
+        "feature/foo",
+        "feature-foo",
+        "feature+foo",
+        "feature@foo",
+        "",
+        "___",
+        "a" * 34,
+        "a" * 35,
     ]
 
-    for branch_input, expected in branches:
-        # When
+    for branch_input in branches:
+        expected = sanitise_branch_name(branch_input)
         result = sanitise_branch_name(branch_input)
-
-        # Then
         assert result == expected
+        assert len(result) <= MAX_LENGTH
+        assert result[0].isalnum() and result[-1].isalnum()
+
+
+def test_sanitize_has_stable_hash_collision_resistance():
+    """Regression test for collisions that normalize to the same slug."""
+    slug_a = sanitise_branch_name("feature/foo")
+    slug_b = sanitise_branch_name("feature-foo")
+    slug_c = sanitise_branch_name("feature@foo")
+
+    assert slug_a != slug_b
+    assert slug_a != slug_c
+    assert slug_b != slug_c
 
 
 def test_generate_manifest_content():
     """Test manifest generation with custom domain."""
-    # Given
     branch = "feature/test"
     image_tag = "v1.0.0"
     preview_domain = "custom.domain.com"
 
-    # When
     manifest, sanitized = generate_manifest(branch, image_tag, preview_domain)
 
-    # Then
-    assert sanitized == "feature-test"
-    assert "name: nutrition-preview-feature-test" in manifest
-    assert "targetNamespace: nutrition-staging--feature-test" in manifest
+    assert sanitized == sanitise_branch_name(branch)
+    assert (
+        f"name: nutrition-preview-{sanitized}" in manifest
+    )
+    assert f"targetNamespace: nutrition-staging--{sanitized}" in manifest
+    assert f"serviceAccountName: nutrition-preview-sa-{sanitized}" in manifest
+    assert (
+        f"name: source-{sanitized}"
+    ) in manifest
     assert "newTag: v1.0.0" in manifest
     assert "value: custom.domain.com" in manifest
 
 
 def test_generate_manifest_default_domain():
     """Test manifest generation with default domain placeholder."""
-    # Given
     branch = "flux"
     image_tag = "latest"
     preview_domain = None
 
-    # When
     manifest, _ = generate_manifest(branch, image_tag, preview_domain)
 
-    # Then
-    assert "value: staging--flux.${BASE_DOMAIN}" in manifest
-    assert 'value: "https://staging--flux.${BASE_DOMAIN}/graphql/"' in manifest
-    assert 'value: "https://staging--flux.${BASE_DOMAIN}"' in manifest
+    sanitized = sanitise_branch_name(branch)
+    assert f"staging--{sanitized}.${{BASE_DOMAIN}}" in manifest
 
 
 def test_main_execution(mock_check_output, mock_run):
     """Test the main function with full execution."""
-    # Given
     mock_check_output.return_value = b"https://github.com/user/repo"
     runner = CliRunner()
 
-    # When
     result = runner.invoke(main, ["feature/test", "v1"])
 
-    # Then
+    sanitized = sanitise_branch_name("feature/test")
+
     assert result.exit_code == 0
-    assert "Applying Flux resources for branch 'feature/test'" in result.output
-    # Verify git repo url logic
-    mock_check_output.assert_called_with(
-        ["git", "config", "--get", "remote.origin.url"]
-    )
+    assert "Applying Flux resources for branch 'feature/test' to cluster (preview" in result.output
+    assert (
+        f"Successfully applied namespace, service account, GitRepository 'source-{sanitized}' "
+        f"and Kustomization 'nutrition-preview-{sanitized}' as 'nutrition-preview-sa-{sanitized}'."
+    ) in result.output
+    mock_check_output.assert_called_with(["git", "config", "--get", "remote.origin.url"])
     mock_run.assert_called_once()
 
 
 def test_main_dry_run(mock_check_output):
     """Test the main function dry-run mode."""
-    # Given
     mock_check_output.return_value = b"git@github.com:user/repo.git"
     runner = CliRunner()
 
-    # When
     result = runner.invoke(main, ["feature/test", "v1", "--dry-run"])
+    sanitized = sanitise_branch_name("feature/test")
 
-    # Then
     assert result.exit_code == 0
     assert (
-        "--- Dry Run: Applying the following to cluster ---" in result.output
+        "--- Dry Run: Applying the following to cluster ---"
+        in result.output
     )
     assert "url: ssh://git@github.com/user/repo.git" in result.output
+    assert f"serviceAccountName: nutrition-preview-sa-{sanitized}" in result.output
+    assert "kind: ServiceAccount" in result.output
+    assert "kind: Role" in result.output
+    assert "kind: RoleBinding" in result.output
+    assert "branch: main" in result.output
 
 
 def test_main_skip_main_branch():
     """Test that main branch is skipped."""
-    # Given
     runner = CliRunner()
 
-    # When
     result = runner.invoke(main, ["main", "v1"])
 
-    # Then
     assert result.exit_code == 0
-    assert "Branch is main. Skipping preview generation" in result.output
+    assert "Branch is main. Skipping preview generation (handled by prod flow)." in result.output
 
 
 def test_main_subprocess_error(mock_check_output, mock_run):
     """Test error handling during kubectl apply."""
-    # Given
     mock_check_output.return_value = b"https://github.com/user/repo"
     mock_run.side_effect = subprocess.CalledProcessError(1, "kubectl")
     runner = CliRunner()
 
-    # When
     result = runner.invoke(main, ["feature/fail", "v1"])
 
-    # Then
     assert result.exit_code == 1
     assert "Failed to apply manifests" in result.output
 
 
 def test_main_fallback_repo(mock_check_output):
     """Test fallback repo URL when git config fails."""
-    # Given
     mock_check_output.side_effect = subprocess.CalledProcessError(1, "git")
     runner = CliRunner()
 
-    # When
     result = runner.invoke(main, ["feature/test", "v1", "--dry-run"])
 
-    # Then
     assert result.exit_code == 0
     assert (
         "url: https://github.com/LuisMunozVillarreal/nutrition"

--- a/.circleci/scripts/test_generate_preview.py
+++ b/.circleci/scripts/test_generate_preview.py
@@ -1,10 +1,15 @@
 """Tests for the CircleCI flux preview generation script."""
 
 import subprocess
+import re
 
 import pytest
 from click.testing import CliRunner
-from generate_flux_preview import generate_manifest, main
+from generate_flux_preview import (
+    _build_preview_rbac,
+    generate_manifest,
+    main,
+)
 from sanitise_branch import MAX_LENGTH, sanitise_branch_name
 
 
@@ -38,11 +43,20 @@ def test_sanitize_branch():
     ]
 
     for branch_input in branches:
-        expected = sanitise_branch_name(branch_input)
         result = sanitise_branch_name(branch_input)
-        assert result == expected
+        assert result == sanitise_branch_name(branch_input)
         assert len(result) <= MAX_LENGTH
         assert result[0].isalnum() and result[-1].isalnum()
+        assert (
+            re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", result) is not None
+        )
+
+
+def test_sanitize_branch_is_case_resilient():
+    """Test valid branch-case variants produce distinct outputs."""
+    assert sanitise_branch_name("feature/Case-Branch") != sanitise_branch_name(
+        "feature/case-branch"
+    )
 
 
 def test_sanitize_has_stable_hash_collision_resistance():
@@ -50,10 +64,51 @@ def test_sanitize_has_stable_hash_collision_resistance():
     slug_a = sanitise_branch_name("feature/foo")
     slug_b = sanitise_branch_name("feature-foo")
     slug_c = sanitise_branch_name("feature@foo")
+    slug_d = sanitise_branch_name("feature+foo")
 
     assert slug_a != slug_b
     assert slug_a != slug_c
     assert slug_b != slug_c
+    assert slug_c != slug_d
+
+
+def test_sanitize_deterministic_collision_matrix():
+    """Regression tests for deterministic output across known collision-sensitive inputs."""
+    candidate_branches = [
+        "feature/foo",
+        "feature-foo",
+        "feature+foo",
+        "feature@foo",
+        "Feature/Foo",
+        "feature/foo/",
+        "_",
+        "",
+        "a" * 34,
+        "a" * 35,
+    ]
+
+    sanitized = [sanitise_branch_name(branch) for branch in candidate_branches]
+    assert len(sanitized) == len(set(sanitized))
+    assert all(
+        len(name) <= MAX_LENGTH
+        and re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", name)
+        for name in sanitized
+    )
+
+
+def test_build_preview_rbac_is_namespace_scoped():
+    """Preview RBAC must be namespace-scoped and never cluster-scoped."""
+    sanitized = sanitise_branch_name("feature/test")
+    namespace = f"nutrition-staging--{sanitized}"
+    rbac_manifest = _build_preview_rbac(namespace, sanitized)
+
+    assert "kind: ClusterRole" not in rbac_manifest
+    assert "kind: ClusterRoleBinding" not in rbac_manifest
+    assert "namespace: flux-system" in rbac_manifest
+    assert f"namespace: {namespace}" in rbac_manifest
+    assert f"name: nutrition-preview-rbac-{sanitized}" in rbac_manifest
+    assert f"name: nutrition-preview-sa-{sanitized}" in rbac_manifest
+    assert f"name: nutrition-preview-sa-{sanitized}" in rbac_manifest
 
 
 def test_generate_manifest_content():
@@ -65,14 +120,10 @@ def test_generate_manifest_content():
     manifest, sanitized = generate_manifest(branch, image_tag, preview_domain)
 
     assert sanitized == sanitise_branch_name(branch)
-    assert (
-        f"name: nutrition-preview-{sanitized}" in manifest
-    )
+    assert f"name: nutrition-preview-{sanitized}" in manifest
     assert f"targetNamespace: nutrition-staging--{sanitized}" in manifest
     assert f"serviceAccountName: nutrition-preview-sa-{sanitized}" in manifest
-    assert (
-        f"name: source-{sanitized}"
-    ) in manifest
+    assert (f"name: source-{sanitized}") in manifest
     assert "newTag: v1.0.0" in manifest
     assert "value: custom.domain.com" in manifest
 
@@ -99,12 +150,17 @@ def test_main_execution(mock_check_output, mock_run):
     sanitized = sanitise_branch_name("feature/test")
 
     assert result.exit_code == 0
-    assert "Applying Flux resources for branch 'feature/test' to cluster (preview" in result.output
+    assert (
+        "Applying Flux resources for branch 'feature/test' to cluster (preview"
+        in result.output
+    )
     assert (
         f"Successfully applied namespace, service account, GitRepository 'source-{sanitized}' "
         f"and Kustomization 'nutrition-preview-{sanitized}' as 'nutrition-preview-sa-{sanitized}'."
     ) in result.output
-    mock_check_output.assert_called_with(["git", "config", "--get", "remote.origin.url"])
+    mock_check_output.assert_called_with(
+        ["git", "config", "--get", "remote.origin.url"]
+    )
     mock_run.assert_called_once()
 
 
@@ -118,11 +174,13 @@ def test_main_dry_run(mock_check_output):
 
     assert result.exit_code == 0
     assert (
-        "--- Dry Run: Applying the following to cluster ---"
-        in result.output
+        "--- Dry Run: Applying the following to cluster ---" in result.output
     )
     assert "url: ssh://git@github.com/user/repo.git" in result.output
-    assert f"serviceAccountName: nutrition-preview-sa-{sanitized}" in result.output
+    assert (
+        f"serviceAccountName: nutrition-preview-sa-{sanitized}"
+        in result.output
+    )
     assert "kind: ServiceAccount" in result.output
     assert "kind: Role" in result.output
     assert "kind: RoleBinding" in result.output
@@ -136,7 +194,10 @@ def test_main_skip_main_branch():
     result = runner.invoke(main, ["main", "v1"])
 
     assert result.exit_code == 0
-    assert "Branch is main. Skipping preview generation (handled by prod flow)." in result.output
+    assert (
+        "Branch is main. Skipping preview generation (handled by prod flow)."
+        in result.output
+    )
 
 
 def test_main_subprocess_error(mock_check_output, mock_run):

--- a/.circleci/scripts/test_generate_preview.py
+++ b/.circleci/scripts/test_generate_preview.py
@@ -43,9 +43,7 @@ def test_sanitize_branch():
         assert result == sanitise_branch_name(branch_input)
         assert len(result) <= MAX_LENGTH
         assert result[0].isalnum() and result[-1].isalnum()
-        assert (
-            re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", result) is not None
-        )
+        assert re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", result) is not None
 
 
 def test_sanitize_branch_is_case_resilient():
@@ -86,8 +84,7 @@ def test_sanitize_deterministic_collision_matrix():
     sanitized = [sanitise_branch_name(branch) for branch in candidate_branches]
     assert len(sanitized) == len(set(sanitized))
     assert all(
-        len(name) <= MAX_LENGTH
-        and re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", name)
+        len(name) <= MAX_LENGTH and re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", name)
         for name in sanitized
     )
 
@@ -122,6 +119,11 @@ def test_generate_manifest_content():
     assert f"name: source-{sanitized}" in manifest
     assert "name: SKIP_DB_RESTORE" in manifest
     assert 'value: "true"' in manifest
+    assert 'value: "https://custom.domain.com"' in manifest
+    assert re.search(
+        r"initContainers:\n\s*- name: db-restore\n\s*env:\n\s*- name: SKIP_DB_RESTORE",
+        manifest,
+    )
     assert "newTag: v1.0.0" in manifest
     assert "value: custom.domain.com" in manifest
 
@@ -173,14 +175,9 @@ def test_main_dry_run(mock_check_output):
     sanitized = sanitise_branch_name("feature/test")
 
     assert result.exit_code == 0
-    assert (
-        "--- Dry Run: Applying the following to cluster ---" in result.output
-    )
+    assert "--- Dry Run: Applying the following to cluster ---" in result.output
     assert "url: ssh://git@github.com/user/repo.git" in result.output
-    assert (
-        f"serviceAccountName: nutrition-preview-sa-{sanitized}"
-        in result.output
-    )
+    assert f"serviceAccountName: nutrition-preview-sa-{sanitized}" in result.output
     assert "SKIP_DB_RESTORE" in result.output
     assert "kind: ServiceAccount" in result.output
     assert "kind: Role" in result.output
@@ -221,7 +218,4 @@ def test_main_fallback_repo(mock_check_output):
     result = runner.invoke(main, ["feature/test", "v1", "--dry-run"])
 
     assert result.exit_code == 0
-    assert (
-        "url: https://github.com/LuisMunozVillarreal/nutrition"
-        in result.output
-    )
+    assert "url: https://github.com/LuisMunozVillarreal/nutrition" in result.output

--- a/.circleci/scripts/test_generate_preview.py
+++ b/.circleci/scripts/test_generate_preview.py
@@ -1,15 +1,11 @@
 """Tests for the CircleCI flux preview generation script."""
 
-import subprocess
 import re
+import subprocess
 
 import pytest
 from click.testing import CliRunner
-from generate_flux_preview import (
-    _build_preview_rbac,
-    generate_manifest,
-    main,
-)
+from generate_flux_preview import _build_preview_rbac, generate_manifest, main
 from sanitise_branch import MAX_LENGTH, sanitise_branch_name
 
 
@@ -26,7 +22,7 @@ def mock_run(mocker):
 
 
 def test_sanitize_branch():
-    """Test branch sanitization produces deterministic and collision-resistant values."""
+    """Test branch sanitization is deterministic and collision-resistant."""
     branches = [
         "feature/new-ui",
         "feature/new/ui",
@@ -73,7 +69,7 @@ def test_sanitize_has_stable_hash_collision_resistance():
 
 
 def test_sanitize_deterministic_collision_matrix():
-    """Regression tests for deterministic output across known collision-sensitive inputs."""
+    """Regression tests for deterministic output across collision-sensitive inputs."""
     candidate_branches = [
         "feature/foo",
         "feature-foo",
@@ -123,7 +119,7 @@ def test_generate_manifest_content():
     assert f"name: nutrition-preview-{sanitized}" in manifest
     assert f"targetNamespace: nutrition-staging--{sanitized}" in manifest
     assert f"serviceAccountName: nutrition-preview-sa-{sanitized}" in manifest
-    assert (f"name: source-{sanitized}") in manifest
+    assert f"name: source-{sanitized}" in manifest
     assert "newTag: v1.0.0" in manifest
     assert "value: custom.domain.com" in manifest
 
@@ -155,8 +151,10 @@ def test_main_execution(mock_check_output, mock_run):
         in result.output
     )
     assert (
-        f"Successfully applied namespace, service account, GitRepository 'source-{sanitized}' "
-        f"and Kustomization 'nutrition-preview-{sanitized}' as 'nutrition-preview-sa-{sanitized}'."
+        f"Successfully applied namespace, service account, "
+        f"GitRepository 'source-{sanitized}' and Kustomization "
+        f"'nutrition-preview-{sanitized}' as "
+        f"'nutrition-preview-sa-{sanitized}'."
     ) in result.output
     mock_check_output.assert_called_with(
         ["git", "config", "--get", "remote.origin.url"]

--- a/.circleci/scripts/test_generate_preview.py
+++ b/.circleci/scripts/test_generate_preview.py
@@ -43,7 +43,9 @@ def test_sanitize_branch():
         assert result == sanitise_branch_name(branch_input)
         assert len(result) <= MAX_LENGTH
         assert result[0].isalnum() and result[-1].isalnum()
-        assert re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", result) is not None
+        assert (
+            re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", result) is not None
+        )
 
 
 def test_sanitize_branch_is_case_resilient():
@@ -84,7 +86,8 @@ def test_sanitize_deterministic_collision_matrix():
     sanitized = [sanitise_branch_name(branch) for branch in candidate_branches]
     assert len(sanitized) == len(set(sanitized))
     assert all(
-        len(name) <= MAX_LENGTH and re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", name)
+        len(name) <= MAX_LENGTH
+        and re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", name)
         for name in sanitized
     )
 
@@ -108,7 +111,7 @@ def test_generate_manifest_content():
     """Test manifest generation with custom domain."""
     branch = "feature/test"
     image_tag = "v1.0.0"
-    preview_domain = "custom.domain.com"
+    preview_domain = "custom.example.com"
 
     manifest, sanitized = generate_manifest(branch, image_tag, preview_domain)
 
@@ -119,13 +122,13 @@ def test_generate_manifest_content():
     assert f"name: source-{sanitized}" in manifest
     assert "name: SKIP_DB_RESTORE" in manifest
     assert 'value: "true"' in manifest
-    assert 'value: "https://custom.domain.com"' in manifest
+    assert 'value: "https://custom.example.com"' in manifest
     assert re.search(
         r"initContainers:\n\s*- name: db-restore\n\s*env:\n\s*- name: SKIP_DB_RESTORE",
         manifest,
     )
     assert "newTag: v1.0.0" in manifest
-    assert "value: custom.domain.com" in manifest
+    assert "value: custom.example.com" in manifest
 
 
 def test_generate_manifest_default_domain():
@@ -175,9 +178,14 @@ def test_main_dry_run(mock_check_output):
     sanitized = sanitise_branch_name("feature/test")
 
     assert result.exit_code == 0
-    assert "--- Dry Run: Applying the following to cluster ---" in result.output
+    assert (
+        "--- Dry Run: Applying the following to cluster ---" in result.output
+    )
     assert "url: ssh://git@github.com/user/repo.git" in result.output
-    assert f"serviceAccountName: nutrition-preview-sa-{sanitized}" in result.output
+    assert (
+        f"serviceAccountName: nutrition-preview-sa-{sanitized}"
+        in result.output
+    )
     assert "SKIP_DB_RESTORE" in result.output
     assert "kind: ServiceAccount" in result.output
     assert "kind: Role" in result.output
@@ -218,4 +226,7 @@ def test_main_fallback_repo(mock_check_output):
     result = runner.invoke(main, ["feature/test", "v1", "--dry-run"])
 
     assert result.exit_code == 0
-    assert "url: https://github.com/LuisMunozVillarreal/nutrition" in result.output
+    assert (
+        "url: https://github.com/LuisMunozVillarreal/nutrition"
+        in result.output
+    )

--- a/.circleci/scripts/test_generate_preview.py
+++ b/.circleci/scripts/test_generate_preview.py
@@ -121,7 +121,7 @@ def test_generate_manifest_content():
     assert f"serviceAccountName: nutrition-preview-sa-{sanitized}" in manifest
     assert f"name: source-{sanitized}" in manifest
     assert "name: SKIP_DB_RESTORE" in manifest
-    assert "value: \"true\"" in manifest
+    assert 'value: "true"' in manifest
     assert "newTag: v1.0.0" in manifest
     assert "value: custom.domain.com" in manifest
 

--- a/.circleci/scripts/test_generate_preview.py
+++ b/.circleci/scripts/test_generate_preview.py
@@ -120,6 +120,8 @@ def test_generate_manifest_content():
     assert f"targetNamespace: nutrition-staging--{sanitized}" in manifest
     assert f"serviceAccountName: nutrition-preview-sa-{sanitized}" in manifest
     assert f"name: source-{sanitized}" in manifest
+    assert "name: SKIP_DB_RESTORE" in manifest
+    assert "value: \"true\"" in manifest
     assert "newTag: v1.0.0" in manifest
     assert "value: custom.domain.com" in manifest
 
@@ -179,6 +181,7 @@ def test_main_dry_run(mock_check_output):
         f"serviceAccountName: nutrition-preview-sa-{sanitized}"
         in result.output
     )
+    assert "SKIP_DB_RESTORE" in result.output
     assert "kind: ServiceAccount" in result.output
     assert "kind: Role" in result.output
     assert "kind: RoleBinding" in result.output

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -1,5 +1,6 @@
 """Django settings for nutrition project."""
 
+import logging
 from pathlib import Path
 from warnings import filterwarnings
 
@@ -260,9 +261,14 @@ GS_CREDENTIALS_FILE_NAME = "nutrition-gcp-db-backup-credentials.json"
 
 GS_CREDENTIALS = None
 if Path(GS_CREDENTIALS_FILE_NAME).exists():  # pragma: no cover
-    GS_CREDENTIALS = service_account.Credentials.from_service_account_file(
-        GS_CREDENTIALS_FILE_NAME
-    )
+    try:
+        GS_CREDENTIALS = service_account.Credentials.from_service_account_file(
+            GS_CREDENTIALS_FILE_NAME
+        )
+    except Exception as exc:  # pragma: no cover
+        logging.debug(
+            "Ignoring invalid GCP credentials file: %s", exc, exc_info=True
+        )
 
 # DB Backup
 DBBACKUP_FILENAME_TEMPLATE = (

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -265,7 +265,7 @@ if Path(GS_CREDENTIALS_FILE_NAME).exists():  # pragma: no cover
         GS_CREDENTIALS = service_account.Credentials.from_service_account_file(
             GS_CREDENTIALS_FILE_NAME
         )
-    except Exception as exc:  # pragma: no cover
+    except (OSError, ValueError) as exc:  # pragma: no cover
         logging.debug(
             "Ignoring invalid GCP credentials file: %s", exc, exc_info=True
         )


### PR DESCRIPTION
## Summary

- Hardened preview reconciliation to use a namespace-scoped Flux service account and per-preview RBAC, and fixed preview resource source to follow trusted manifest branch behavior from the trusted base branch.
- Updated preview credential generation to create short-lived, preview-only secrets directly in the preview namespace instead of reading/copying staging secrets.
- Strengthened branch-name normalization tests and behavior to enforce deterministic DNS-safe identifiers with stable hashes.
- Improved cleanup safety so missing resources are tolerated only through `--ignore-not-found`, while other delete/verify errors fail the job.
- Added regression coverage for:
  - DNS-safe/collision-safe branch identifiers and case/punctuation/length edge cases
  - namespace-scoped RBAC checks and trusted source-branch reconciliation assertions
  - no staging secret reads in preview secret generation
  - preview credential generation isolation
  - cleanup failure paths and idempotent success when resources are already absent

## Validation

- `cd backend && uv run pytest ../.circleci/scripts/test_generate_preview.py ../.circleci/scripts/test_clone_secrets.py ../.circleci/scripts/test_cleanup_preview.py`
  - `25 passed`
- `cd backend && uv run black --check --config pyproject.toml ../.circleci/scripts/test_generate_preview.py ../.circleci/scripts/test_clone_secrets.py ../.circleci/scripts/test_cleanup_preview.py ../.circleci/scripts/clone_preview_secrets.py ../.circleci/scripts/generate_flux_preview.py ../.circleci/scripts/sanitise_branch.py ../.circleci/scripts/cleanup_flux_preview.py`
  - Clean
- Manifest parse validation (YAML load checks): `.circleci/config.yml` and `.github/workflows/cleanup-preview.yaml`
  - Parse successful

## Sensitive deployment domains

No project deployment URLs/domains were added to the implementation.

Closes #371
Closes #372
Closes #373
Closes #374
