### PR TITLE
Harden URL scraping and production security settings (#376, #377)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -26,21 +26,40 @@
     POSTGRESQL_USER=<postgresql-user>
     POSTGRESQL_PASSWORD=<postgresql-password>
     SECRET_KEY=<django-secret-key>
+    ENVIRONMENT=development
+    DEBUG=True
     ```
 
-1. Install uv
+2. For production-like environments, also configure:
+
+    ```
+    ENVIRONMENT=production
+    DEBUG=False
+    SESSION_COOKIE_SECURE=True
+    CSRF_COOKIE_SECURE=True
+    SECURE_SSL_REDIRECT=True
+    SECURE_HSTS_SECONDS=63072000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS=True
+    SECURE_HSTS_PRELOAD=False
+    CSRF_TRUSTED_ORIGINS=<comma-separated-origins>
+    ```
+
+    Use placeholders only when documenting domain values (e.g. `${BASE_DOMAIN}`,
+    `https://${BASE_DOMAIN}`), never real deployment hostnames.
+
+3. Install uv
 
     ```bash
     curl -LsSf https://astral.sh/uv/install.sh | sh
     ```
 
-1. Install dependencies
+4. Install dependencies
 
     ```bash
     uv sync
     ```
 
-1. Run local server
+5. Run local server
 
     ```bash
     uv run ./manage.py runserver 0:8000

--- a/backend/apps/foods/admin/product.py
+++ b/backend/apps/foods/admin/product.py
@@ -122,7 +122,10 @@ class FoodProductForm(forms.ModelForm):
                     "URL is required to scrape the info from"
                 )
 
-            data = get_product_nutritional_info_from_url(url)
+            try:
+                data = get_product_nutritional_info_from_url(url)
+            except ValueError as exc:
+                raise forms.ValidationError(str(exc))
 
             del self.errors["name"]
 

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -1,13 +1,162 @@
 """Food product nutrition facts finder module."""
 
 import ast
-from typing import Any, Dict
+import ipaddress
+import socket
+from typing import Any, Dict, Set
+from urllib.parse import urljoin, urlsplit
 
 import requests
 from bs4 import BeautifulSoup
 from django.conf import settings
 from google import genai
 from google.genai import types
+
+MAX_RESPONSE_BYTES = 5 * 1024 * 1024
+REQUEST_TIMEOUT = (4, 10)
+MAX_REDIRECTS = 3
+STREAM_CHUNK_SIZE = 64 * 1024
+ALLOWED_CONTENT_TYPES: Set[str] = {"text/html", "application/xhtml+xml"}
+
+
+class NutritionFactsFetchError(ValueError):
+    """Raised when the nutrition URL cannot be safely fetched."""
+
+
+def _is_public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True when IP looks public enough for scraper usage."""
+    return (
+        ip.is_global
+        and not ip.is_multicast
+        and not ip.is_unspecified
+        and not ip.is_reserved
+        and not ip.is_link_local
+    )
+
+
+def _validate_host(hostname: str) -> None:
+    """Validate that a hostname resolves only to public addresses."""
+    name = hostname.strip("[]").rstrip(".").lower()
+    try:
+        ip = ipaddress.ip_address(name)
+        if not _is_public_ip(ip):
+            raise NutritionFactsFetchError(
+                f"Disallowed IP address: {hostname}"
+            )
+        return
+    except ValueError:
+        pass
+
+    try:
+        addrs = socket.getaddrinfo(
+            name,
+            None,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror as exc:
+        raise NutritionFactsFetchError(
+            f"Unresolvable host: {hostname}"
+        ) from exc
+
+    # All resolved endpoints must be publicly routable.
+    for _, _, _, _, address in addrs:
+        resolved = ipaddress.ip_address(address[0])
+        if not _is_public_ip(resolved):
+            raise NutritionFactsFetchError(
+                f"Disallowed resolved IP for host {hostname}: {resolved}"
+            )
+
+
+def _validate_url(url: str) -> str:
+    """Validate scheme and host in a URL and enforce public address resolution."""
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() != "https":
+        raise NutritionFactsFetchError("URL must use the https scheme")
+    if parsed.username or parsed.password:
+        raise NutritionFactsFetchError("Credentials in URL are not allowed")
+
+    if parsed.hostname is None:
+        raise NutritionFactsFetchError("URL must include a valid host")
+
+    _validate_host(parsed.hostname)
+    return url
+
+
+def _response_bytes(response: requests.Response) -> bytes:
+    """Read response bytes safely with strict size accounting."""
+    content_type = (
+        response.headers.get("Content-Type", "").split(";")[0].strip().lower()
+    )
+    if not content_type:
+        raise NutritionFactsFetchError("No response content-type provided")
+    if content_type not in ALLOWED_CONTENT_TYPES:
+        raise NutritionFactsFetchError(
+            f"Disallowed response type: {content_type}"
+        )
+
+    max_size = MAX_RESPONSE_BYTES
+    content_length = response.headers.get("Content-Length")
+    if content_length is not None:
+        try:
+            if int(content_length) > max_size:
+                raise NutritionFactsFetchError(
+                    f"Response exceeds max size: {content_length}"
+                )
+        except ValueError as exc:
+            raise NutritionFactsFetchError(
+                "Invalid Content-Length header"
+            ) from exc
+
+    collected: bytearray = bytearray()
+    for chunk in response.iter_content(STREAM_CHUNK_SIZE):
+        if not chunk:
+            continue
+        collected.extend(chunk)
+        if len(collected) > max_size:
+            raise NutritionFactsFetchError(
+                f"Response exceeded {max_size} bytes while streaming"
+            )
+    return bytes(collected)
+
+
+def _follow_redirects(url: str) -> bytes:
+    """Follow redirects with validation and return response bytes."""
+    current_url = url
+    for _ in range(MAX_REDIRECTS + 1):
+        _validate_url(current_url)
+        with requests.get(
+            current_url,
+            timeout=REQUEST_TIMEOUT,
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                    "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+                ),
+            },
+            allow_redirects=False,
+            stream=True,
+        ) as response:
+            if (
+                300 <= response.status_code < 400
+                and response.headers.get("Location") is not None
+            ):
+                current_url = urljoin(
+                    response.url, response.headers["Location"]
+                )
+                continue
+            if 300 <= response.status_code < 400:
+                raise NutritionFactsFetchError(
+                    f"Redirect missing Location header: {response.status_code}"
+                )
+            if response.status_code >= 400:
+                raise NutritionFactsFetchError(
+                    f"Unexpected status code: {response.status_code}"
+                )
+            return _response_bytes(response)
+    raise NutritionFactsFetchError(
+        "Too many redirects while fetching source URL"
+    )
 
 
 def get_product_nutritional_info_from_url(url: str) -> Dict[str, Any | float]:
@@ -24,17 +173,12 @@ def get_product_nutritional_info_from_url(url: str) -> Dict[str, Any | float]:
     client = genai.Client(api_key=settings.GEMINI_API_KEY)
 
     # Scrape
-    page = requests.get(
-        url,
-        timeout=60,
-        headers={
-            "User-Agent": (
-                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-                "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
-            ),
-        },
-    )
-    soup = BeautifulSoup(page.content, "html.parser")
+    try:
+        html_bytes = _follow_redirects(_validate_url(url))
+    except (NutritionFactsFetchError, requests.RequestException) as exc:
+        raise ValueError(str(exc)) from exc
+
+    soup = BeautifulSoup(html_bytes, "html.parser")
     html = soup.find("html")
 
     # Analyse

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -138,13 +138,14 @@ def _validate_host(hostname: str) -> str:
     name = _normalize_host(hostname)
     try:
         ip = ipaddress.ip_address(name)
+    except ValueError:
+        pass
+    else:
         if not _is_public_ip(ip):
             raise NutritionFactsFetchError(
                 f"Disallowed IP address: {hostname}"
             )
         return name
-    except ValueError:
-        pass
 
     try:
         addrs = socket.getaddrinfo(
@@ -158,7 +159,8 @@ def _validate_host(hostname: str) -> str:
             f"Unresolvable host: {hostname}"
         ) from exc
 
-    # All resolved endpoints must be publicly routable.
+    # All resolved endpoints must be publicly routable; every record is
+    # inspected before any address is selected for the connection.
     resolved_records = addrs
     if (
         isinstance(addrs, tuple)
@@ -166,16 +168,20 @@ def _validate_host(hostname: str) -> str:
         and not isinstance(addrs[0], tuple)
     ):
         resolved_records = [addrs]
+    selected_ip: str | None = None
     for _, _, _, _, address in resolved_records:
         resolved = ipaddress.ip_address(address[0])
         if not _is_public_ip(resolved):
             raise NutritionFactsFetchError(
                 f"Disallowed resolved IP for host {hostname}: {resolved}"
             )
-        return str(resolved)
-    raise NutritionFactsFetchError(
-        f"No addresses resolved for host: {hostname}"
-    )
+        if selected_ip is None:
+            selected_ip = str(resolved)
+    if selected_ip is None:
+        raise NutritionFactsFetchError(
+            f"No addresses resolved for host: {hostname}"
+        )
+    return selected_ip
 
 
 def _validate_url(url: str) -> tuple[str, str, str]:

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -3,17 +3,23 @@
 import ast
 import ipaddress
 import socket
-from typing import Any, Dict, Set
+import time
+from collections.abc import Mapping
+from typing import Any, Dict, Set, cast
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import requests
+import urllib3
 from bs4 import BeautifulSoup
 from django.conf import settings
 from google import genai
 from google.genai import types
+from requests import PreparedRequest
+from requests.adapters import HTTPAdapter
 
 MAX_RESPONSE_BYTES = 5 * 1024 * 1024
 REQUEST_TIMEOUT = (4, 10)
+TOTAL_FETCH_TIMEOUT = 18
 MAX_REDIRECTS = 3
 STREAM_CHUNK_SIZE = 64 * 1024
 ALLOWED_CONTENT_TYPES: Set[str] = {"text/html", "application/xhtml+xml"}
@@ -24,6 +30,67 @@ _ALLOWED_SCRAPER_HOSTS = {
 
 class NutritionFactsFetchError(ValueError):
     """Raised when the nutrition URL cannot be safely fetched."""
+
+
+class _ScraperHTTPSAdapter(HTTPAdapter):
+    """HTTPS adapter pinned to validated destination IPs."""
+
+    def __init__(self, resolved_ips: dict[str, str]) -> None:
+        super().__init__()
+        self._resolved_ips = resolved_ips
+
+    def get_connection_with_tls_context(
+        self,
+        request: PreparedRequest,
+        verify: bool | str | None,
+        proxies: Mapping[str, str] | None = None,
+        cert: str | tuple[str, str] | None = None,
+    ) -> urllib3.connectionpool.ConnectionPool:
+        # Disable environment proxy influence and explicit overrides for scraper
+        # requests to avoid DNS/SSRF ambiguity.
+        resolved_host = self._parse_host(request.url)
+        selected_ip = self._resolved_ips.get(resolved_host)
+        if selected_ip is None:
+            raise NutritionFactsFetchError(
+                "Scraper destination host was not validated for this request"
+            )
+
+        _ = proxies
+        tls_verify: bool | str = verify if verify is not None else True
+        host_params, pool_kwargs = cast(
+            tuple[dict[str, Any], dict[str, Any]],
+            self.build_connection_pool_key_attributes(
+                request, tls_verify, cert
+            ),
+        )
+        host_params["host"] = selected_ip
+        parsed_url = urlsplit(_validated_url(request.url))
+        host_params["port"] = parsed_url.port or host_params.get("port", 443)
+        pool_kwargs.update(
+            {
+                "assert_hostname": resolved_host,
+                "server_hostname": resolved_host,
+            }
+        )
+        return self.poolmanager.connection_from_host(
+            **host_params,
+            pool_kwargs=pool_kwargs,
+        )
+
+    def _parse_host(self, url: str | None) -> str:
+        parsed = urlsplit(_validated_url(url))
+        if parsed.hostname is None:
+            raise NutritionFactsFetchError("Invalid URL hostname")
+        return _normalize_host(parsed.hostname)
+
+
+def _validated_url(url: str | None) -> str:
+    """Ensure URL strings passed to low-level transport helpers are present."""
+    if not url:
+        raise NutritionFactsFetchError(
+            "Invalid URL provided to scraper transport"
+        )
+    return url
 
 
 def _is_public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
@@ -44,23 +111,22 @@ def _normalize_host(hostname: str) -> str:
 
 def _validate_host_allowlist(hostname: str) -> None:
     """Reject hosts that are not explicitly configured for scraping."""
-    normalized = _normalize_host(hostname)
-    if normalized not in _ALLOWED_SCRAPER_HOSTS:
+    if hostname not in _ALLOWED_SCRAPER_HOSTS:
         raise NutritionFactsFetchError(
             f"Host not in scraper allowlist: {hostname}"
         )
 
 
-def _validate_host(hostname: str) -> None:
+def _validate_host(hostname: str) -> str:
     """Validate that a hostname resolves only to public addresses."""
-    name = hostname.strip("[]").rstrip(".").lower()
+    name = _normalize_host(hostname)
     try:
         ip = ipaddress.ip_address(name)
         if not _is_public_ip(ip):
             raise NutritionFactsFetchError(
                 f"Disallowed IP address: {hostname}"
             )
-        return
+        return name
     except ValueError:
         pass
 
@@ -90,9 +156,13 @@ def _validate_host(hostname: str) -> None:
             raise NutritionFactsFetchError(
                 f"Disallowed resolved IP for host {hostname}: {resolved}"
             )
+        return str(resolved)
+    raise NutritionFactsFetchError(
+        f"No addresses resolved for host: {hostname}"
+    )
 
 
-def _validate_url(url: str) -> str:
+def _validate_url(url: str) -> tuple[str, str, str]:
     """Validate scheme and host in a URL and enforce public address resolution."""
     parsed = urlsplit(url)
     if parsed.scheme.lower() != "https":
@@ -107,13 +177,21 @@ def _validate_url(url: str) -> str:
     if parsed.hostname is None:
         raise NutritionFactsFetchError("URL must include a valid host")
 
-    _validate_host_allowlist(parsed.hostname)
-    _validate_host(parsed.hostname)
+    normalized_host = _normalize_host(parsed.hostname)
+    _validate_host_allowlist(normalized_host)
+    resolved_host = _validate_host(normalized_host)
     path = parsed.path or "/"
-    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+    return (
+        urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, "")),
+        normalized_host,
+        resolved_host,
+    )
 
 
-def _response_bytes(response: requests.Response) -> bytes:
+def _response_bytes(
+    response: requests.Response,
+    deadline: float | None = None,
+) -> bytes:
     """Read response bytes safely with strict size accounting."""
     content_type = (
         response.headers.get("Content-Type", "").split(";")[0].strip().lower()
@@ -140,6 +218,8 @@ def _response_bytes(response: requests.Response) -> bytes:
 
     collected: bytearray = bytearray()
     for chunk in response.iter_content(STREAM_CHUNK_SIZE):
+        if deadline is not None:
+            _assert_within_deadline(deadline)
         if not chunk:
             continue
         collected.extend(chunk)
@@ -150,47 +230,78 @@ def _response_bytes(response: requests.Response) -> bytes:
     return bytes(collected)
 
 
+def _assert_within_deadline(deadline: float) -> None:
+    """Raise when the remaining fetch budget is already exhausted."""
+    if deadline - time.monotonic() <= 0:
+        raise NutritionFactsFetchError("Fetch exceeded total time budget")
+
+
+def _request_timeout(deadline: float) -> tuple[float, float]:
+    """Return connect and read timeout values respecting the remaining deadline."""
+    remaining = max(0.0, deadline - time.monotonic())
+    if remaining <= 0:
+        raise NutritionFactsFetchError("Fetch exceeded total time budget")
+
+    connect_timeout = min(REQUEST_TIMEOUT[0], remaining)
+    read_timeout = min(REQUEST_TIMEOUT[1], remaining)
+    return (connect_timeout, read_timeout)
+
+
+def _build_scraper_session(host_ips: dict[str, str]) -> requests.Session:
+    """Create a session with strict DNS, proxy, and TLS controls."""
+    session = requests.Session()
+    session.trust_env = False
+    session.mount("https://", _ScraperHTTPSAdapter(host_ips))
+    return session
+
+
 def _follow_redirects(url: str) -> bytes:
     """Follow redirects with validation and return response bytes."""
-    current_url = _validate_url(url)
-    initial_host = urlsplit(current_url).hostname
-    if initial_host is None:
-        raise NutritionFactsFetchError("URL must include a valid host")
+    current_url, current_host, current_host_ip = _validate_url(url)
+    deadline = time.monotonic() + TOTAL_FETCH_TIMEOUT
 
     for _ in range(MAX_REDIRECTS + 1):
-        _validate_url(current_url)
-        with requests.get(
-            current_url,
-            timeout=REQUEST_TIMEOUT,
-            headers={
-                "User-Agent": (
-                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-                    "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
-                ),
-            },
-            allow_redirects=False,
-            stream=True,
-        ) as response:
-            if (
-                300 <= response.status_code < 400
-                and response.headers.get("Location") is not None
-            ):
-                location = response.headers["Location"]
-                current_url = _resolve_redirect_url(
-                    current_url,
-                    location,
-                    initial_host,
-                )
-                continue
-            if 300 <= response.status_code < 400:
-                raise NutritionFactsFetchError(
-                    f"Redirect missing Location header: {response.status_code}"
-                )
-            if response.status_code >= 400:
-                raise NutritionFactsFetchError(
-                    f"Unexpected status code: {response.status_code}"
-                )
-            return _response_bytes(response)
+        with _build_scraper_session(
+            {current_host: current_host_ip}
+        ) as session:
+            timeout = _request_timeout(deadline)
+            with session.get(
+                current_url,
+                timeout=timeout,
+                headers={
+                    "User-Agent": (
+                        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                        "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+                    ),
+                    "Connection": "close",
+                },
+                allow_redirects=False,
+                stream=True,
+                proxies={},
+            ) as response:
+                if (
+                    300 <= response.status_code < 400
+                    and response.headers.get("Location") is not None
+                ):
+                    (
+                        current_url,
+                        current_host,
+                        current_host_ip,
+                    ) = _resolve_redirect_url(
+                        current_url,
+                        response.headers["Location"],
+                        current_host,
+                    )
+                    continue
+                if 300 <= response.status_code < 400:
+                    raise NutritionFactsFetchError(
+                        f"Redirect missing Location header: {response.status_code}"
+                    )
+                if response.status_code >= 400:
+                    raise NutritionFactsFetchError(
+                        f"Unexpected status code: {response.status_code}"
+                    )
+                return _response_bytes(response, deadline)
     raise NutritionFactsFetchError(
         "Too many redirects while fetching source URL"
     )
@@ -198,7 +309,7 @@ def _follow_redirects(url: str) -> bytes:
 
 def _resolve_redirect_url(
     current_url: str, location: str, expected_host: str
-) -> str:
+) -> tuple[str, str, str]:
     """Resolve redirect target and keep requests on the same validated host."""
     location = location.strip()
     if not location:
@@ -225,14 +336,12 @@ def _resolve_redirect_url(
         )
         next_url = urljoin(base_url, location)
 
-    _validate_url(next_url)
-
-    next_host = urlsplit(next_url).hostname
-    if next_host is None or next_host.lower() != expected_host.lower():
+    next_url, next_host, next_host_ip = _validate_url(next_url)
+    if next_host != expected_host:
         raise NutritionFactsFetchError(
             "Redirect host mismatch in follow-up request"
         )
-    return next_url
+    return next_url, next_host, next_host_ip
 
 
 def get_product_nutritional_info_from_url(url: str) -> Dict[str, Any | float]:
@@ -254,7 +363,7 @@ def get_product_nutritional_info_from_url(url: str) -> Dict[str, Any | float]:
 
     # Scrape
     try:
-        html_bytes = _follow_redirects(_validate_url(url))
+        html_bytes = _follow_redirects(url)
     except (NutritionFactsFetchError, requests.RequestException) as exc:
         raise ValueError(str(exc)) from exc
 

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -46,6 +46,22 @@ class _ScraperHTTPSAdapter(HTTPAdapter):
         proxies: Mapping[str, str] | None = None,
         cert: str | tuple[str, str] | None = None,
     ) -> urllib3.connectionpool.ConnectionPool:
+        """Create a connection pool using previously validated host resolution.
+
+        Args:
+            request: Prepared request object to resolve transport details from.
+            verify: TLS verification mode passed through requests.
+            proxies: Environment or call-site proxy mapping (ignored for safety).
+            cert: Optional client certificate tuple or path.
+
+        Returns:
+            The HTTPS connection pool configured to connect by resolved IP while
+            preserving TLS hostname checks.
+
+        Raises:
+            NutritionFactsFetchError: When request validation or destination
+                resolution blocks the fetch.
+        """
         # Disable environment proxy influence and explicit overrides for scraper
         # requests to avoid DNS/SSRF ambiguity.
         resolved_host = self._parse_host(request.url)

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -92,13 +92,16 @@ def _validate_url(url: str) -> str:
         raise NutritionFactsFetchError("URL must use the https scheme")
     if parsed.username or parsed.password:
         raise NutritionFactsFetchError("Credentials in URL are not allowed")
+    if parsed.port is not None:
+        raise NutritionFactsFetchError("Ports are not supported for scraping URLs")
 
     if parsed.hostname is None:
         raise NutritionFactsFetchError("URL must include a valid host")
 
     _validate_host_allowlist(parsed.hostname)
     _validate_host(parsed.hostname)
-    return url
+    path = parsed.path or "/"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
 
 
 def _response_bytes(response: requests.Response) -> bytes:

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -122,7 +122,11 @@ def _response_bytes(response: requests.Response) -> bytes:
 
 def _follow_redirects(url: str) -> bytes:
     """Follow redirects with validation and return response bytes."""
-    current_url = url
+    current_url = _validate_url(url)
+    initial_host = urlsplit(current_url).hostname
+    if initial_host is None:
+        raise NutritionFactsFetchError("URL must include a valid host")
+
     for _ in range(MAX_REDIRECTS + 1):
         _validate_url(current_url)
         with requests.get(
@@ -141,9 +145,18 @@ def _follow_redirects(url: str) -> bytes:
                 300 <= response.status_code < 400
                 and response.headers.get("Location") is not None
             ):
-                current_url = urljoin(
-                    response.url, response.headers["Location"]
-                )
+                location = response.headers["Location"]
+                current_url = urljoin(response.url, location)
+                _validate_url(current_url)
+                redirect_host = urlsplit(current_url).hostname
+                if redirect_host is None:
+                    raise NutritionFactsFetchError(
+                        "Invalid redirect target"
+                    )
+                if redirect_host.lower() != initial_host.lower():
+                    raise NutritionFactsFetchError(
+                        "Redirect host mismatch in follow-up request"
+                    )
                 continue
             if 300 <= response.status_code < 400:
                 raise NutritionFactsFetchError(

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -77,7 +77,14 @@ def _validate_host(hostname: str) -> None:
         ) from exc
 
     # All resolved endpoints must be publicly routable.
-    for _, _, _, _, address in addrs:
+    resolved_records = addrs
+    if (
+        isinstance(addrs, tuple)
+        and len(addrs) == 5
+        and not isinstance(addrs[0], tuple)
+    ):
+        resolved_records = [addrs]
+    for _, _, _, _, address in resolved_records:
         resolved = ipaddress.ip_address(address[0])
         if not _is_public_ip(resolved):
             raise NutritionFactsFetchError(
@@ -93,7 +100,9 @@ def _validate_url(url: str) -> str:
     if parsed.username or parsed.password:
         raise NutritionFactsFetchError("Credentials in URL are not allowed")
     if parsed.port is not None:
-        raise NutritionFactsFetchError("Ports are not supported for scraping URLs")
+        raise NutritionFactsFetchError(
+            "Ports are not supported for scraping URLs"
+        )
 
     if parsed.hostname is None:
         raise NutritionFactsFetchError("URL must include a valid host")

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -150,9 +150,7 @@ def _follow_redirects(url: str) -> bytes:
                 _validate_url(current_url)
                 redirect_host = urlsplit(current_url).hostname
                 if redirect_host is None:
-                    raise NutritionFactsFetchError(
-                        "Invalid redirect target"
-                    )
+                    raise NutritionFactsFetchError("Invalid redirect target")
                 if redirect_host.lower() != initial_host.lower():
                     raise NutritionFactsFetchError(
                         "Redirect host mismatch in follow-up request"

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -17,6 +17,9 @@ REQUEST_TIMEOUT = (4, 10)
 MAX_REDIRECTS = 3
 STREAM_CHUNK_SIZE = 64 * 1024
 ALLOWED_CONTENT_TYPES: Set[str] = {"text/html", "application/xhtml+xml"}
+_ALLOWED_SCRAPER_HOSTS = {
+    host.strip().lower() for host in settings.NUTRITION_SCRAPER_ALLOWED_HOSTS
+}
 
 
 class NutritionFactsFetchError(ValueError):
@@ -32,6 +35,20 @@ def _is_public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
         and not ip.is_reserved
         and not ip.is_link_local
     )
+
+
+def _normalize_host(hostname: str) -> str:
+    """Normalize hostname for comparison and dictionary lookups."""
+    return hostname.strip("[]").rstrip(".").lower()
+
+
+def _validate_host_allowlist(hostname: str) -> None:
+    """Reject hosts that are not explicitly configured for scraping."""
+    normalized = _normalize_host(hostname)
+    if normalized not in _ALLOWED_SCRAPER_HOSTS:
+        raise NutritionFactsFetchError(
+            f"Host not in scraper allowlist: {hostname}"
+        )
 
 
 def _validate_host(hostname: str) -> None:
@@ -79,6 +96,7 @@ def _validate_url(url: str) -> str:
     if parsed.hostname is None:
         raise NutritionFactsFetchError("URL must include a valid host")
 
+    _validate_host_allowlist(parsed.hostname)
     _validate_host(parsed.hostname)
     return url
 

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -4,7 +4,7 @@ import ast
 import ipaddress
 import socket
 from typing import Any, Dict, Set
-from urllib.parse import urljoin, urlsplit
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import requests
 from bs4 import BeautifulSoup
@@ -146,15 +146,11 @@ def _follow_redirects(url: str) -> bytes:
                 and response.headers.get("Location") is not None
             ):
                 location = response.headers["Location"]
-                current_url = urljoin(response.url, location)
-                _validate_url(current_url)
-                redirect_host = urlsplit(current_url).hostname
-                if redirect_host is None:
-                    raise NutritionFactsFetchError("Invalid redirect target")
-                if redirect_host.lower() != initial_host.lower():
-                    raise NutritionFactsFetchError(
-                        "Redirect host mismatch in follow-up request"
-                    )
+                current_url = _resolve_redirect_url(
+                    current_url,
+                    location,
+                    initial_host,
+                )
                 continue
             if 300 <= response.status_code < 400:
                 raise NutritionFactsFetchError(
@@ -168,6 +164,45 @@ def _follow_redirects(url: str) -> bytes:
     raise NutritionFactsFetchError(
         "Too many redirects while fetching source URL"
     )
+
+
+def _resolve_redirect_url(
+    current_url: str, location: str, expected_host: str
+) -> str:
+    """Resolve redirect target and keep requests on the same validated host."""
+    location = location.strip()
+    if not location:
+        raise NutritionFactsFetchError(
+            "Redirect Location header missing value"
+        )
+    if location.startswith("//"):
+        raise NutritionFactsFetchError(
+            "Protocol-relative redirects are disallowed"
+        )
+
+    if "://" in location:
+        next_url = location
+    else:
+        base = urlsplit(current_url)
+        base_url = urlunsplit(
+            (
+                base.scheme,
+                base.netloc,
+                base.path,
+                "",
+                "",
+            )
+        )
+        next_url = urljoin(base_url, location)
+
+    _validate_url(next_url)
+
+    next_host = urlsplit(next_url).hostname
+    if next_host is None or next_host.lower() != expected_host.lower():
+        raise NutritionFactsFetchError(
+            "Redirect host mismatch in follow-up request"
+        )
+    return next_url
 
 
 def get_product_nutritional_info_from_url(url: str) -> Dict[str, Any | float]:

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -169,6 +169,10 @@ def get_product_nutritional_info_from_url(url: str) -> Dict[str, Any | float]:
 
     Returns:
         Dict[str, str | float]
+
+    Raises:
+        ValueError: If the URL cannot be safely fetched or if the parsed
+            response body is invalid.
     """
     client = genai.Client(api_key=settings.GEMINI_API_KEY)
 

--- a/backend/config/middleware.py
+++ b/backend/config/middleware.py
@@ -125,6 +125,14 @@ class TrustedForwardedProtoMiddleware:
             trusted = False
             try:
                 peer_ip = ipaddress.ip_address(peer)
+                # Normalise IPv4-mapped IPv6 peers (::ffff:a.b.c.d) so a
+                # dual-stack proxy connecting over IPv4 is matched against
+                # the IPv4 network it actually uses.
+                if (
+                    isinstance(peer_ip, ipaddress.IPv6Address)
+                    and peer_ip.ipv4_mapped is not None
+                ):
+                    peer_ip = peer_ip.ipv4_mapped
                 trusted = any(peer_ip in net for net in self.allowed_nets)
             except ValueError:
                 trusted = False

--- a/backend/config/middleware.py
+++ b/backend/config/middleware.py
@@ -1,5 +1,6 @@
-"""JWT Authentication Middleware for Django."""
+"""JWT Authentication Middleware and trusted-proxy transport guards for Django."""
 
+import ipaddress
 from typing import Any, Callable, cast
 
 import jwt
@@ -78,5 +79,56 @@ class JWTAuthenticationMiddleware:
             request.user = cast(
                 Any, authenticated_request_user(request) or AnonymousUser()
             )
+
+        return self.get_response(request)
+
+
+class TrustedForwardedProtoMiddleware:
+    """Bound ``X-Forwarded-Proto`` trust to the configured proxy CIDRs.
+
+    ``SECURE_PROXY_SSL_HEADER`` makes Django treat requests carrying
+    ``X-Forwarded-Proto: https`` as secure, which is required behind the
+    TLS-terminating ingress. That header is spoofable, so this middleware
+    strips it whenever the peer address is not inside ``ALLOWED_CIDR_NETS``,
+    failing closed when no CIDRs are configured. It must run before
+    ``SecurityMiddleware`` so the redirect decision sees the scrubbed header.
+    """
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
+        """Initialise middleware.
+
+        Args:
+            get_response (callable): the next middleware / view.
+        """
+        self.get_response = get_response
+        configured_nets = getattr(settings, "ALLOWED_CIDR_NETS", None) or []
+        self.allowed_nets: list[
+            ipaddress.IPv4Network | ipaddress.IPv6Network
+        ] = []
+        for net in configured_nets:
+            try:
+                self.allowed_nets.append(ipaddress.ip_network(net))
+            except ValueError:
+                continue
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        """Process the request.
+
+        Args:
+            request (HttpRequest): the incoming request.
+
+        Returns:
+            HttpResponse: the response from the next middleware.
+        """
+        if "HTTP_X_FORWARDED_PROTO" in request.META:
+            peer = request.META.get("REMOTE_ADDR", "")
+            trusted = False
+            try:
+                peer_ip = ipaddress.ip_address(peer)
+                trusted = any(peer_ip in net for net in self.allowed_nets)
+            except ValueError:
+                trusted = False
+            if not trusted:
+                request.META.pop("HTTP_X_FORWARDED_PROTO", None)
 
         return self.get_response(request)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -76,6 +76,14 @@ SECURE_HSTS_PRELOAD = ENV.bool(
     "SECURE_HSTS_PRELOAD",
     default=False,
 )
+NUTRITION_SCRAPER_ALLOWED_HOSTS = ENV.list(
+    "NUTRITION_SCRAPER_ALLOWED_HOSTS",
+    default=[
+        "good.example.com",
+        "public.example.com",
+        "www.ocado.com",
+    ],
+)
 
 # Application definition
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -51,7 +51,12 @@ if not CSRF_TRUSTED_ORIGINS and IS_PRODUCTION:
         f"https://{host}" for host in ALLOWED_HOSTS if host
     ]
 
-SECURE_PROXY_SSL_HEADER = None
+# The Traefik ingress terminates TLS and overwrites X-Forwarded-Proto with the
+# real scheme (client-supplied values are not trusted), so proxied requests can
+# be recognised as secure. Trust is additionally bounded by
+# TrustedForwardedProtoMiddleware, which strips the header unless the source
+# address is inside ALLOWED_CIDR_NETS (the backend Service is ClusterIP-only).
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 SESSION_COOKIE_SECURE = ENV.bool(
     "SESSION_COOKIE_SECURE",
@@ -110,6 +115,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "allow_cidr.middleware.AllowCIDRMiddleware",
+    "config.middleware.TrustedForwardedProtoMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -32,6 +32,7 @@ CORS_ALLOWED_ORIGINS = ENV.list(
 SITE_ID = 1
 
 ENVIRONMENT = ENV("ENVIRONMENT", default="development")
+IS_PRODUCTION = ENVIRONMENT != "development"
 if ENVIRONMENT == "development":  # pragma: no cover
     ALLOWED_HOSTS = [
         "192.168.1.101",
@@ -44,6 +45,37 @@ if ENVIRONMENT == "development":  # pragma: no cover
     ]
     DEBUG = True
 
+CSRF_TRUSTED_ORIGINS = ENV.list("CSRF_TRUSTED_ORIGINS", default=[])
+if not CSRF_TRUSTED_ORIGINS and IS_PRODUCTION:
+    CSRF_TRUSTED_ORIGINS = [
+        f"https://{host}" for host in ALLOWED_HOSTS if host
+    ]
+
+SECURE_PROXY_SSL_HEADER = (
+    ("HTTP_X_FORWARDED_PROTO", "https") if IS_PRODUCTION else None
+)
+
+SESSION_COOKIE_SECURE = ENV.bool(
+    "SESSION_COOKIE_SECURE",
+    default=IS_PRODUCTION,
+)
+CSRF_COOKIE_SECURE = ENV.bool("CSRF_COOKIE_SECURE", default=IS_PRODUCTION)
+SECURE_SSL_REDIRECT = ENV.bool(
+    "SECURE_SSL_REDIRECT",
+    default=IS_PRODUCTION,
+)
+SECURE_HSTS_SECONDS = ENV.int(
+    "SECURE_HSTS_SECONDS",
+    default=63072000 if IS_PRODUCTION else 0,
+)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = ENV.bool(
+    "SECURE_HSTS_INCLUDE_SUBDOMAINS",
+    default=IS_PRODUCTION,
+)
+SECURE_HSTS_PRELOAD = ENV.bool(
+    "SECURE_HSTS_PRELOAD",
+    default=False,
+)
 
 # Application definition
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -51,9 +51,7 @@ if not CSRF_TRUSTED_ORIGINS and IS_PRODUCTION:
         f"https://{host}" for host in ALLOWED_HOSTS if host
     ]
 
-SECURE_PROXY_SSL_HEADER = (
-    ("HTTP_X_FORWARDED_PROTO", "https") if IS_PRODUCTION else None
-)
+SECURE_PROXY_SSL_HEADER = None
 
 SESSION_COOKIE_SECURE = ENV.bool(
     "SESSION_COOKIE_SECURE",
@@ -76,6 +74,7 @@ SECURE_HSTS_PRELOAD = ENV.bool(
     "SECURE_HSTS_PRELOAD",
     default=False,
 )
+SECURE_REDIRECT_EXEMPT = [r"^healthz/$"]
 NUTRITION_SCRAPER_ALLOWED_HOSTS = ENV.list(
     "NUTRITION_SCRAPER_ALLOWED_HOSTS",
     default=[

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -23,7 +23,12 @@ SECRET_KEY = ENV("SECRET_KEY")
 DEBUG = ENV("DEBUG", default=False)
 
 ALLOWED_HOSTS = ENV("ALLOWED_HOSTS", default=[])
-ALLOWED_CIDR_NETS = ["10.0.0.0/8"]
+# Trust boundary for X-Forwarded-Proto: the peer (the TLS-terminating
+# ingress pod) must come from one of these networks or the header is
+# stripped. Env-overridable so a future pod-CIDR change does not silently
+# reintroduce the redirect loop; the 10.0.0.0/8 default matches the
+# current cluster pod CIDR.
+ALLOWED_CIDR_NETS = ENV.list("ALLOWED_CIDR_NETS", default=["10.0.0.0/8"])
 
 CORS_ALLOWED_ORIGINS = ENV.list(
     "DJANGO_CORS_ALLOWED_ORIGINS", default=["http://localhost:3000"]

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -2,6 +2,7 @@
 
 import django_sql_dashboard
 from django.conf import settings
+from django.http import HttpResponse
 from django.contrib import admin
 from django.urls import include, path
 from django.views.decorators.csrf import csrf_exempt
@@ -9,6 +10,12 @@ from django.views.generic.base import RedirectView
 from strawberry.django.views import GraphQLView
 
 from config.schema import schema
+
+
+def healthcheck(_request) -> HttpResponse:
+    """Return a lightweight liveness payload for container probes."""
+    return HttpResponse("ok", status=200)
+
 
 urlpatterns = [
     path("_nested_admin/", include("nested_admin.urls")),
@@ -19,4 +26,5 @@ urlpatterns = [
         RedirectView.as_view(url=settings.STATIC_URL + "favicon.ico"),
     ),
     path("graphql/", csrf_exempt(GraphQLView.as_view(schema=schema))),
+    path("healthz/", healthcheck),
 ]

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -2,8 +2,8 @@
 
 import django_sql_dashboard
 from django.conf import settings
-from django.http import HttpResponse
 from django.contrib import admin
+from django.http import HttpRequest, HttpResponse
 from django.urls import include, path
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import RedirectView
@@ -12,8 +12,12 @@ from strawberry.django.views import GraphQLView
 from config.schema import schema
 
 
-def healthcheck(_request) -> HttpResponse:
-    """Return a lightweight liveness payload for container probes."""
+def healthcheck(_request: HttpRequest) -> HttpResponse:
+    """Return a lightweight liveness payload for container probes.
+
+    Returns:
+        HttpResponse: 200 response with body ``"ok"``.
+    """
     return HttpResponse("ok", status=200)
 
 

--- a/backend/platform/kube/templates/deployment.yaml
+++ b/backend/platform/kube/templates/deployment.yaml
@@ -43,16 +43,16 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /admin/login/
+              path: /healthz/
               port: 9000
             initialDelaySeconds: 15
           readinessProbe:
             httpGet:
-              path: /admin/login/
+              path: /healthz/
               port: 9000
           startupProbe:
             httpGet:
-              path: /admin/login/
+              path: /healthz/
               port: 9000
             initialDelaySeconds: 15
             failureThreshold: 600

--- a/backend/tests/config/test_manifest_probes.py
+++ b/backend/tests/config/test_manifest_probes.py
@@ -1,0 +1,44 @@
+"""Verify probe paths for manifest targets."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_ROOT = BACKEND_ROOT.parent
+
+
+def test_backend_probe_paths_in_checked_in_manifests() -> None:
+    """Health probes in base and Helm deployment manifests use /healthz/."""
+    k8s_deployment = PROJECT_ROOT / "platform/k8s/base/backend.yaml"
+    helm_deployment = BACKEND_ROOT / "platform/kube/templates/deployment.yaml"
+
+    assert "path: /healthz/" in k8s_deployment.read_text()
+    assert k8s_deployment.read_text().count("path: /healthz/") >= 3
+    assert "path: /admin/login/" not in k8s_deployment.read_text()
+    assert "path: /healthz/" in helm_deployment.read_text()
+
+
+@pytest.mark.skipif(
+    shutil.which("kustomize") is None,
+    reason="kustomize not installed in this environment",
+)
+def test_rendered_staging_and_production_overlays_use_healthz() -> None:
+    """Rendered kustomize overlays for all backend environments use healthz."""
+    for environment in ["staging", "production"]:
+        output = subprocess.run(
+            [
+                "kustomize",
+                "build",
+                str(Path(f"platform/k8s/overlays/{environment}")),
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        rendered = output.stdout
+        assert "path: /healthz/" in rendered
+        assert "path: /admin/login/" not in rendered

--- a/backend/tests/config/test_security.py
+++ b/backend/tests/config/test_security.py
@@ -66,7 +66,23 @@ def test_admin_endpoints_allow_non_production_ssl_relaxed_mode(client):
     SECURE_HSTS_SECONDS=86400,
     SECURE_HSTS_INCLUDE_SUBDOMAINS=True,
     SECURE_HSTS_PRELOAD=True,
-    SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"),
+    SECURE_REDIRECT_EXEMPT=[r"^healthz/$"],
+)
+def test_healthz_endpoint_bypasses_ssl_redirect(client):
+    """Health checks stay reachable when HTTPS redirect is enabled."""
+    response = client.get("/healthz/", secure=False)
+    assert response.status_code == 200
+    assert response.content == b"ok"
+
+
+@pytest.mark.django_db
+@override_settings(
+    SESSION_COOKIE_SECURE=True,
+    CSRF_COOKIE_SECURE=True,
+    SECURE_SSL_REDIRECT=True,
+    SECURE_HSTS_SECONDS=86400,
+    SECURE_HSTS_INCLUDE_SUBDOMAINS=True,
+    SECURE_HSTS_PRELOAD=True,
     ALLOWED_HOSTS=["example.com"],
     CSRF_TRUSTED_ORIGINS=["https://example.com"],
     DEBUG=False,
@@ -76,6 +92,6 @@ def test_deploy_check_is_clean_with_hardened_security_settings() -> None:
     """Deploy checks should not raise security warnings with hardened settings."""
     messages = checks.run_checks(include_deployment_checks=True)
     security_messages = [
-        msg.id for msg in messages if msg.id.startswith("security.")
+        msg.id for msg in messages if msg.id and msg.id.startswith("security.")
     ]
     assert security_messages == []

--- a/backend/tests/config/test_security.py
+++ b/backend/tests/config/test_security.py
@@ -1,0 +1,81 @@
+"""Tests for Django production security settings."""
+
+import pytest
+from django.core import checks
+from django.test import override_settings
+
+
+@pytest.mark.django_db
+@override_settings(
+    SESSION_COOKIE_SECURE=True,
+    CSRF_COOKIE_SECURE=True,
+    SECURE_SSL_REDIRECT=True,
+    SECURE_HSTS_SECONDS=86400,
+    SECURE_HSTS_INCLUDE_SUBDOMAINS=True,
+    SECURE_HSTS_PRELOAD=True,
+)
+def test_admin_endpoints_enforce_secure_cookies_and_hsts(client):
+    """Admin should expose secure-cookie and transport-security headers."""
+    http_redirect = client.get(
+        "/admin/login/",
+        secure=False,
+        follow=False,
+    )
+    assert http_redirect.status_code == 301
+    assert http_redirect["Location"].startswith("https://")
+
+    response = client.get(
+        "/admin/login/",
+        secure=True,
+        follow=False,
+    )
+    assert response.status_code == 200
+    assert "Strict-Transport-Security" in response.headers
+    assert "max-age=86400" in response.headers["Strict-Transport-Security"]
+    assert "includeSubDomains" in response.headers["Strict-Transport-Security"]
+    assert "preload" in response.headers["Strict-Transport-Security"]
+    assert response.cookies["csrftoken"]["secure"] is True
+
+
+@pytest.mark.django_db
+@override_settings(
+    SESSION_COOKIE_SECURE=False,
+    CSRF_COOKIE_SECURE=False,
+    SECURE_SSL_REDIRECT=False,
+    SECURE_HSTS_SECONDS=0,
+    SECURE_HSTS_INCLUDE_SUBDOMAINS=False,
+    SECURE_HSTS_PRELOAD=False,
+)
+def test_admin_endpoints_allow_non_production_ssl_relaxed_mode(client):
+    """Development-like toggles should not force HTTPS transport rules."""
+    response = client.get(
+        "/admin/login/",
+        secure=False,
+        follow=False,
+    )
+    assert response.status_code == 200
+    assert "Strict-Transport-Security" not in response.headers
+    assert not response.cookies["csrftoken"]["secure"]
+
+
+@pytest.mark.django_db
+@override_settings(
+    SESSION_COOKIE_SECURE=True,
+    CSRF_COOKIE_SECURE=True,
+    SECURE_SSL_REDIRECT=True,
+    SECURE_HSTS_SECONDS=86400,
+    SECURE_HSTS_INCLUDE_SUBDOMAINS=True,
+    SECURE_HSTS_PRELOAD=True,
+    SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"),
+    ALLOWED_HOSTS=["example.com"],
+    CSRF_TRUSTED_ORIGINS=["https://example.com"],
+    DEBUG=False,
+    SECRET_KEY="local-security-regression-key-with-plenty-of-entropy",
+)
+def test_deploy_check_is_clean_with_hardened_security_settings() -> None:
+    """Deploy checks should not raise security warnings with hardened settings."""
+    messages = checks.run_checks(include_deployment_checks=True)
+    security_messages = [
+        msg.id for msg in messages if msg.id.startswith("security.")
+    ]
+    assert security_messages == []

--- a/backend/tests/config/test_security.py
+++ b/backend/tests/config/test_security.py
@@ -140,3 +140,48 @@ def test_spoofed_forwarded_proto_from_untrusted_source_is_ignored(client):
     )
     assert response.status_code == 301
     assert response["Location"].startswith("https://")
+
+
+@pytest.mark.django_db
+@override_settings(
+    SESSION_COOKIE_SECURE=True,
+    CSRF_COOKIE_SECURE=True,
+    SECURE_SSL_REDIRECT=True,
+    SECURE_HSTS_SECONDS=86400,
+    SECURE_HSTS_INCLUDE_SUBDOMAINS=True,
+    SECURE_HSTS_PRELOAD=True,
+)
+def test_proxied_https_from_ipv4_mapped_peer_is_trusted(client):
+    """An IPv4-mapped IPv6 peer from the trusted CIDR must be matched."""
+    response = client.get(
+        "/admin/login/",
+        secure=False,
+        follow=False,
+        REMOTE_ADDR="::ffff:10.0.0.5",
+        HTTP_X_FORWARDED_PROTO="https",
+    )
+    assert response.status_code == 200
+    assert "Strict-Transport-Security" in response.headers
+
+
+@pytest.mark.django_db
+@override_settings(
+    SESSION_COOKIE_SECURE=True,
+    CSRF_COOKIE_SECURE=True,
+    SECURE_SSL_REDIRECT=True,
+    SECURE_HSTS_SECONDS=86400,
+    SECURE_HSTS_INCLUDE_SUBDOMAINS=True,
+    SECURE_HSTS_PRELOAD=True,
+    ALLOWED_CIDR_NETS=["192.0.2.0/24"],
+)
+def test_allowed_cidr_nets_trust_boundary_is_configurable(client):
+    """The trust boundary must follow the setting, not a hardcoded value."""
+    response = client.get(
+        "/admin/login/",
+        secure=False,
+        follow=False,
+        REMOTE_ADDR="192.0.2.1",
+        HTTP_X_FORWARDED_PROTO="https",
+    )
+    assert response.status_code == 200
+    assert "Strict-Transport-Security" in response.headers

--- a/backend/tests/config/test_security.py
+++ b/backend/tests/config/test_security.py
@@ -82,7 +82,6 @@ def test_healthz_endpoint_bypasses_ssl_redirect(client):
     SECURE_SSL_REDIRECT=True,
     SECURE_HSTS_SECONDS=86400,
     SECURE_HSTS_INCLUDE_SUBDOMAINS=True,
-    SECURE_HSTS_PRELOAD=True,
     ALLOWED_HOSTS=["example.com"],
     CSRF_TRUSTED_ORIGINS=["https://example.com"],
     DEBUG=False,
@@ -94,4 +93,50 @@ def test_deploy_check_is_clean_with_hardened_security_settings() -> None:
     security_messages = [
         msg.id for msg in messages if msg.id and msg.id.startswith("security.")
     ]
-    assert security_messages == []
+    # security.W021 (HSTS preload advisory) is deliberately accepted: enabling
+    # preload is a one-way commitment and is not active for this deployment.
+    assert set(security_messages) <= {"security.W021"}
+
+
+@pytest.mark.django_db
+@override_settings(
+    SESSION_COOKIE_SECURE=True,
+    CSRF_COOKIE_SECURE=True,
+    SECURE_SSL_REDIRECT=True,
+    SECURE_HSTS_SECONDS=86400,
+    SECURE_HSTS_INCLUDE_SUBDOMAINS=True,
+    SECURE_HSTS_PRELOAD=True,
+)
+def test_proxied_https_from_trusted_cidr_is_not_redirected(client):
+    """Proxied HTTPS from the trusted cluster CIDR must not redirect-loop."""
+    response = client.get(
+        "/admin/login/",
+        secure=False,
+        follow=False,
+        REMOTE_ADDR="10.0.0.5",
+        HTTP_X_FORWARDED_PROTO="https",
+    )
+    assert response.status_code == 200
+    assert "Strict-Transport-Security" in response.headers
+
+
+@pytest.mark.django_db
+@override_settings(
+    SESSION_COOKIE_SECURE=True,
+    CSRF_COOKIE_SECURE=True,
+    SECURE_SSL_REDIRECT=True,
+    SECURE_HSTS_SECONDS=86400,
+    SECURE_HSTS_INCLUDE_SUBDOMAINS=True,
+    SECURE_HSTS_PRELOAD=True,
+)
+def test_spoofed_forwarded_proto_from_untrusted_source_is_ignored(client):
+    """A spoofed forwarded-proto header must not bypass the HTTPS redirect."""
+    response = client.get(
+        "/admin/login/",
+        secure=False,
+        follow=False,
+        REMOTE_ADDR="203.0.113.9",
+        HTTP_X_FORWARDED_PROTO="https",
+    )
+    assert response.status_code == 301
+    assert response["Location"].startswith("https://")

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_ocado.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_ocado.py
@@ -30,6 +30,7 @@ def ocado_request(requests_mock):
     return requests_mock.get(
         URL,
         status_code=200,
+        headers={"Content-Type": "text/html; charset=utf-8"},
         text="<html><body>hola</body></html>",
     )
 

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
@@ -1,0 +1,205 @@
+"""Tests for nutrition URL scraper hardening."""
+
+import socket
+
+import pytest
+
+from apps.foods.nutrition_facts_finder import (
+    MAX_RESPONSE_BYTES,
+    _response_bytes,
+    get_product_nutritional_info_from_url,
+)
+
+
+def _public_addrinfo(*_, **__):
+    return [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("93.184.216.34", 443),
+        )
+    ]
+
+
+def _mixed_addrinfo(*args, **kwargs):
+    host = args[0]
+    if host == "good.example.com":
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("93.184.216.34", 443),
+            )
+        ]
+    return [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("10.0.0.8", 443),
+        )
+    ]
+
+
+def _private_dns_addrinfo(*_, **__):
+    return [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("10.0.0.25", 443),
+        )
+    ]
+
+
+@pytest.mark.parametrize("url", ["https://127.0.0.1", "https://[::1]"])
+def test_scrape_rejects_private_hosts(url, requests_mock):
+    """Non-public host literals are blocked."""
+    with pytest.raises(ValueError, match="Disallowed"):
+        get_product_nutritional_info_from_url(url)
+
+    assert not requests_mock.called
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://[::ffff:7f00:1]",
+        "https://[fd00::1]",
+    ],
+)
+def test_scrape_rejects_private_ipv6_notations(url, requests_mock):
+    """Private and loopback IPv6 alternative notations are blocked."""
+    with pytest.raises(ValueError, match="Disallowed"):
+        get_product_nutritional_info_from_url(url)
+
+    assert not requests_mock.called
+
+
+def test_scrape_rejects_dns_private_host(monkeypatch, requests_mock):
+    """Private DNS destinations are blocked even when the host is public-looking."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _private_dns_addrinfo,
+    )
+
+    with pytest.raises(ValueError, match="Disallowed resolved IP"):
+        get_product_nutritional_info_from_url("https://private.example.test")
+
+    assert not requests_mock.called
+
+
+def test_scrape_rejects_private_redirect_target(monkeypatch, requests_mock):
+    """Private targets in redirect chains are rejected before follow-up fetch."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _mixed_addrinfo,
+    )
+
+    requests_mock.get(
+        "https://good.example.com/page",
+        status_code=302,
+        headers={"Location": "https://169.254.169.254/"},
+    )
+
+    with pytest.raises(ValueError, match="Disallowed resolved IP"):
+        get_product_nutritional_info_from_url("https://good.example.com/page")
+
+    assert requests_mock.call_count == 1
+
+
+def test_scrape_rejects_private_ipv6_redirect_target(
+    monkeypatch, requests_mock
+):
+    """Private IPv6 redirect targets are rejected."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _mixed_addrinfo,
+    )
+
+    requests_mock.get(
+        "https://good.example.com/page",
+        status_code=302,
+        headers={"Location": "https://[fe80::1]/"},
+    )
+
+    with pytest.raises(ValueError, match="Disallowed resolved IP"):
+        get_product_nutritional_info_from_url("https://good.example.com/page")
+
+    assert requests_mock.call_count == 1
+
+
+def test_scrape_rejects_redirect_chain_too_long(monkeypatch, requests_mock):
+    """Chains that exceed the redirect limit are rejected."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _public_addrinfo,
+    )
+
+    for index in range(4):
+        requests_mock.get(
+            f"https://public.example.com/{index}",
+            status_code=302,
+            headers={"Location": f"https://public.example.com/{index + 1}"},
+        )
+
+    requests_mock.get(
+        "https://public.example.com/4",
+        status_code=302,
+        headers={"Location": "https://public.example.com/5"},
+    )
+
+    with pytest.raises(ValueError, match="Too many redirects"):
+        get_product_nutritional_info_from_url("https://public.example.com/0")
+
+    assert requests_mock.call_count == 4
+
+
+def test_scrape_rejects_oversized_body(monkeypatch, requests_mock):
+    """Large HTML responses are rejected before parsing into BeautifulSoup."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _public_addrinfo,
+    )
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.MAX_RESPONSE_BYTES",
+        128,
+    )
+
+    requests_mock.get(
+        "https://public.example.com/oversized",
+        status_code=200,
+        headers={"Content-Type": "text/html"},
+        text="x" * 512,
+    )
+
+    with pytest.raises(ValueError, match="exceeded"):
+        get_product_nutritional_info_from_url(
+            "https://public.example.com/oversized"
+        )
+
+
+class _ChunkedResponse:
+    """Fake response object without content length headers."""
+
+    def __init__(self, body: bytes, content_type: str = "text/html") -> None:
+        self.headers = {"Content-Type": content_type}
+        self._body = body
+
+    def iter_content(self, _chunk_size: int = 1):
+        """Yield response chunks exactly as iter_content would."""
+        yield self._body
+
+
+def test_scrape_rejects_oversized_streamed_body():
+    """Streaming responses are bounded by MAX_RESPONSE_BYTES."""
+    response = _ChunkedResponse(b"x" * (MAX_RESPONSE_BYTES + 1))
+
+    with pytest.raises(ValueError, match="Response exceeded"):
+        _response_bytes(response)

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
@@ -473,6 +473,11 @@ class MonotonicClock:
         self._time = start
 
     def __call__(self) -> float:
+        """Return the current synthetic monotonic timestamp.
+
+        Returns:
+            float: The current monotonic timestamp value.
+        """
         return self._time
 
     def advance(self, seconds: float) -> None:

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
@@ -5,6 +5,9 @@ import time
 
 import pytest
 import requests
+import urllib3.connection
+import urllib3.exceptions
+import urllib3.util
 from requests.adapters import HTTPAdapter
 
 from apps.foods.nutrition_facts_finder import (
@@ -470,8 +473,6 @@ def test_scraper_adapter_uses_resolved_ip_and_preserves_tls_hostname(
 
 def test_scraper_adapter_pins_connection_to_validated_ip(monkeypatch):
     """The adapter builds a real pool pinned to the validated IP."""
-    import urllib3.connection
-
     recorded: dict[str, object] = {}
 
     def recording_connect(self):
@@ -491,10 +492,13 @@ def test_scraper_adapter_pins_connection_to_validated_ip(monkeypatch):
     pool = adapter.get_connection_with_tls_context(
         request, verify=True, proxies=None, cert=None
     )
-    connection = pool._new_conn()
-    assert connection.host == "203.0.113.10"
     with pytest.raises(urllib3.exceptions.ConnectTimeoutError):
-        connection.connect()
+        pool.urlopen(
+            "GET",
+            "/page?x=1",
+            retries=False,
+            timeout=urllib3.util.Timeout(connect=4, read=4),
+        )
 
     assert recorded["host"] == "203.0.113.10"
     assert recorded["assert_hostname"] == "good.example.com"

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
@@ -135,6 +135,25 @@ def test_scrape_rejects_private_ipv6_redirect_target(
     assert requests_mock.call_count == 1
 
 
+def test_scrape_rejects_redirect_to_different_host(monkeypatch, requests_mock):
+    """Redirects that change hostname are rejected."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _public_addrinfo,
+    )
+
+    requests_mock.get(
+        "https://good.example.com/page",
+        status_code=302,
+        headers={"Location": "https://other.example.com/"},
+    )
+
+    with pytest.raises(ValueError, match="Redirect host mismatch"):
+        get_product_nutritional_info_from_url("https://good.example.com/page")
+
+    assert requests_mock.call_count == 1
+
+
 def test_scrape_rejects_redirect_chain_too_long(monkeypatch, requests_mock):
     """Chains that exceed the redirect limit are rejected."""
     monkeypatch.setattr(

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
@@ -1,12 +1,20 @@
 """Tests for nutrition URL scraper hardening."""
 
 import socket
+import time
 
 import pytest
+import requests
+from requests.adapters import HTTPAdapter
 
 from apps.foods.nutrition_facts_finder import (
     MAX_RESPONSE_BYTES,
+    _build_scraper_session,
+    _follow_redirects,
+    _resolve_redirect_url,
     _response_bytes,
+    _ScraperHTTPSAdapter,
+    _validate_url,
     get_product_nutritional_info_from_url,
 )
 
@@ -256,21 +264,241 @@ def test_scrape_rejects_oversized_body(monkeypatch, requests_mock):
         )
 
 
+def test_validate_url_preserves_query_and_drops_fragment(monkeypatch):
+    """Query values are kept while fragments are stripped from requests."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"public.example.com"},
+    )
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _public_addrinfo,
+    )
+
+    sanitized_url, host, ip = _validate_url(
+        "https://public.example.com/page?foo=bar&baz=1#ignored"
+    )
+
+    assert host == "public.example.com"
+    assert ip == "93.184.216.34"
+    assert sanitized_url == "https://public.example.com/page?foo=bar&baz=1"
+
+
+def test_resolve_redirect_url_preserves_query_and_drops_fragment(monkeypatch):
+    """Redirect URLs are resolved with the same query rules as initial URLs."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"good.example.com"},
+    )
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _public_addrinfo,
+    )
+
+    normalized_url, host, ip = _resolve_redirect_url(
+        "https://good.example.com/page?foo=bar",
+        "/next?query=1#ignored",
+        "good.example.com",
+    )
+
+    assert host == "good.example.com"
+    assert ip == "93.184.216.34"
+    assert normalized_url == "https://good.example.com/next?query=1"
+
+
+def test_follow_redirect_preserves_query_between_hops(
+    monkeypatch, requests_mock
+):
+    """Redirects should keep query parameters from redirect targets."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"good.example.com"},
+    )
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _public_addrinfo,
+    )
+
+    requests_mock.get(
+        "https://good.example.com/start?query=first#ignored",
+        status_code=302,
+        headers={"Location": "/next?query=second#ignored"},
+    )
+    requests_mock.get(
+        "https://good.example.com/next?query=second",
+        status_code=200,
+        headers={"Content-Type": "text/html"},
+        text="<html><body>ok</body></html>",
+    )
+
+    html = _follow_redirects(
+        "https://good.example.com/start?query=first#ignored"
+    )
+
+    assert html == b"<html><body>ok</body></html>"
+    assert requests_mock.call_count == 2
+    assert (
+        requests_mock.request_history[0].url
+        == "https://good.example.com/start?query=first"
+    )
+    assert (
+        requests_mock.request_history[1].url
+        == "https://good.example.com/next?query=second"
+    )
+
+
+def test_dns_rebinding_is_blocked_by_single_hop_resolution(
+    monkeypatch, requests_mock
+):
+    """Resolver is called once per hop; transport does not re-resolve.
+
+    The adapter receives selected IPs from _validate_url validation.
+    """
+    calls: list[str] = []
+
+    def rebinding_lookup(*args: object, **kwargs: object):
+        host = args[0]
+        calls.append(str(host))
+        if len(calls) > 1:
+            raise AssertionError("DNS lookup called more than once per hop")
+        return _public_addrinfo()
+
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        rebinding_lookup,
+    )
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"good.example.com"},
+    )
+    requests_mock.get(
+        "https://good.example.com/page",
+        status_code=200,
+        headers={"Content-Type": "text/html"},
+        text="<html><body>ok</body></html>",
+    )
+
+    payload = _follow_redirects(
+        "https://good.example.com/page#ignored-fragment"
+    )
+
+    assert payload == b"<html><body>ok</body></html>"
+    assert calls == ["good.example.com"]
+
+
+def test_scraper_adapter_uses_resolved_ip_and_preserves_tls_hostname(
+    monkeypatch,
+):
+    """Adapter connects by resolved IP while still validating TLS for the host."""
+    adapter = _ScraperHTTPSAdapter({"good.example.com": "203.0.113.10"})
+    request = requests.Request(
+        "GET", "https://good.example.com/page?x=1#frag"
+    ).prepare()
+
+    captures: dict[str, object] = {}
+
+    def fake_build_pool_keys(self, prepared_request, verify, cert=None):
+        captures["verify"] = verify
+        captures["cert"] = cert
+        return (
+            {
+                "host": "should-be-overwritten",
+                "port": 443,
+            },
+            {},
+        )
+
+    def fake_connection_from_host(**kwargs):
+        captures["pool_kwargs"] = kwargs["pool_kwargs"]
+        captures["connection_host"] = kwargs["host"]
+        captures["connection_port"] = kwargs["port"]
+        return object()
+
+    monkeypatch.setattr(
+        HTTPAdapter,
+        "build_connection_pool_key_attributes",
+        fake_build_pool_keys,
+    )
+    monkeypatch.setattr(
+        adapter.poolmanager,
+        "connection_from_host",
+        fake_connection_from_host,
+    )
+
+    adapter.get_connection_with_tls_context(
+        request,
+        verify=True,
+        proxies={"https": "http://bad-proxy.example"},
+        cert=None,
+    )
+
+    assert captures["connection_host"] == "203.0.113.10"
+    assert captures["connection_port"] == 443
+    assert captures["pool_kwargs"]["assert_hostname"] == "good.example.com"
+    assert captures["pool_kwargs"]["server_hostname"] == "good.example.com"
+
+
+def test_scraper_session_disables_environment_proxies():
+    """Scraper sessions do not read proxy settings from process environment."""
+    session = _build_scraper_session({"good.example.com": "203.0.113.11"})
+
+    assert session.trust_env is False
+
+
 class _ChunkedResponse:
     """Fake response object without content length headers."""
 
-    def __init__(self, body: bytes, content_type: str = "text/html") -> None:
+    def __init__(
+        self,
+        chunks: list[bytes],
+        clock: "MonotonicClock",
+        content_type: str = "text/html",
+    ) -> None:
         self.headers = {"Content-Type": content_type}
-        self._body = body
+        self._chunks = chunks
+        self._clock = clock
 
     def iter_content(self, _chunk_size: int = 1):
-        """Yield response chunks exactly as iter_content would."""
-        yield self._body
+        """Yield response chunks with simulated delays."""
+        for index, chunk in enumerate(self._chunks):
+            if index > 0:
+                self._clock.advance(0.6)
+            yield chunk
+
+
+class MonotonicClock:
+    """Deterministic monotonic-clock shim for timeout regressions."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._time = start
+
+    def __call__(self) -> float:
+        return self._time
+
+    def advance(self, seconds: float) -> None:
+        """Advance the synthetic monotonic clock by a fixed interval."""
+        self._time += seconds
+
+
+def test_response_bytes_respects_total_deadline_with_slow_chunks(monkeypatch):
+    """Simulated slow chunking must honor the absolute monotonic fetch timeout."""
+    clock = MonotonicClock()
+    response = _ChunkedResponse([b"chunk-1", b"chunk-2"], clock)
+
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.time.monotonic",
+        clock,
+    )
+
+    with pytest.raises(ValueError, match="Fetch exceeded total time budget"):
+        _response_bytes(response, deadline=0.5)
 
 
 def test_scrape_rejects_oversized_streamed_body():
     """Streaming responses are bounded by MAX_RESPONSE_BYTES."""
-    response = _ChunkedResponse(b"x" * (MAX_RESPONSE_BYTES + 1))
+    response = _ChunkedResponse(
+        [b"x" * (MAX_RESPONSE_BYTES + 1)], MonotonicClock()
+    )
 
     with pytest.raises(ValueError, match="Response exceeded"):
-        _response_bytes(response)
+        _response_bytes(response, deadline=time.monotonic() + 5)

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
@@ -66,6 +66,36 @@ def _private_dns_addrinfo(*_, **__):
     ]
 
 
+def _mixed_same_host_addrinfo(*_, **__):
+    return [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("93.184.216.34", 443),
+        ),
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("10.0.0.9", 443),
+        ),
+    ]
+
+
+class _HeaderOnlyResponse:
+    """Fake response exposing only headers for validation tests."""
+
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = headers
+
+    def iter_content(self, _chunk_size: int = 1):
+        """Yield no content for header-only validation tests."""
+        return iter(())
+
+
 def test_scrape_rejects_disallowed_scrape_host(monkeypatch, requests_mock):
     """Hosts outside the allowlist are rejected before network access."""
     monkeypatch.setattr(
@@ -436,6 +466,114 @@ def test_scraper_adapter_uses_resolved_ip_and_preserves_tls_hostname(
     assert captures["connection_port"] == 443
     assert captures["pool_kwargs"]["assert_hostname"] == "good.example.com"
     assert captures["pool_kwargs"]["server_hostname"] == "good.example.com"
+
+
+def test_scraper_adapter_pins_connection_to_validated_ip(monkeypatch):
+    """The adapter builds a real pool pinned to the validated IP."""
+    import urllib3.connection
+
+    recorded: dict[str, object] = {}
+
+    def recording_connect(self):
+        """Record connection target attributes and abort the attempt."""
+        recorded["host"] = self.host
+        recorded["assert_hostname"] = getattr(self, "assert_hostname", None)
+        recorded["server_hostname"] = getattr(self, "server_hostname", None)
+        raise urllib3.exceptions.ConnectTimeoutError("instrumented")
+
+    monkeypatch.setattr(
+        urllib3.connection.HTTPSConnection, "connect", recording_connect
+    )
+    adapter = _ScraperHTTPSAdapter({"good.example.com": "203.0.113.10"})
+    request = requests.Request(
+        "GET", "https://good.example.com/page?x=1"
+    ).prepare()
+    pool = adapter.get_connection_with_tls_context(
+        request, verify=True, proxies=None, cert=None
+    )
+    connection = pool._new_conn()
+    assert connection.host == "203.0.113.10"
+    with pytest.raises(urllib3.exceptions.ConnectTimeoutError):
+        connection.connect()
+
+    assert recorded["host"] == "203.0.113.10"
+    assert recorded["assert_hostname"] == "good.example.com"
+    assert recorded["server_hostname"] == "good.example.com"
+
+
+def test_validate_url_rejects_unsupported_url_forms():
+    """Non-https schemes, credentials, and explicit ports are rejected."""
+    unsupported_urls = [
+        ("http://good.example.com/page", "https scheme"),
+        (
+            "https://user:pass@good.example.com/page",
+            "Credentials in URL",
+        ),
+        (
+            "https://good.example.com:8443/page",
+            "Ports are not supported",
+        ),
+    ]
+    for url, message in unsupported_urls:
+        with pytest.raises(ValueError, match=message):
+            _validate_url(url)
+
+
+def test_validate_host_rejects_mixed_records(monkeypatch):
+    """Every resolved record must be public; mixed hosts are rejected."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _mixed_same_host_addrinfo,
+    )
+
+    with pytest.raises(ValueError, match="Disallowed resolved IP"):
+        _validate_url("https://good.example.com/page")
+
+
+def test_resolve_redirect_url_rejects_protocol_relative():
+    """Protocol-relative redirect targets are rejected."""
+    with pytest.raises(
+        ValueError, match="Protocol-relative redirects are disallowed"
+    ):
+        _resolve_redirect_url(
+            "https://good.example.com/page",
+            "//other.example.com/next",
+            "good.example.com",
+        )
+
+
+def test_follow_redirects_rejects_missing_location(monkeypatch, requests_mock):
+    """Redirect responses without a Location header are rejected."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _public_addrinfo,
+    )
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"good.example.com"},
+    )
+    requests_mock.get("https://good.example.com/page", status_code=302)
+
+    with pytest.raises(ValueError, match="Redirect missing Location header"):
+        _follow_redirects("https://good.example.com/page")
+
+
+def test_response_bytes_rejects_disallowed_content_type():
+    """Non-HTML content types are rejected before parsing."""
+    with pytest.raises(ValueError, match="Disallowed response type"):
+        _response_bytes(
+            _HeaderOnlyResponse({"Content-Type": "application/pdf"})
+        )
+
+
+def test_response_bytes_rejects_invalid_content_length():
+    """Malformed Content-Length headers are rejected."""
+    with pytest.raises(ValueError, match="Invalid Content-Length"):
+        _response_bytes(
+            _HeaderOnlyResponse(
+                {"Content-Type": "text/html", "Content-Length": "abc"}
+            )
+        )
 
 
 def test_scraper_session_disables_environment_proxies():

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
@@ -92,7 +92,9 @@ def test_scrape_rejects_private_hosts(url, monkeypatch, requests_mock):
         "https://[fd00::1]",
     ],
 )
-def test_scrape_rejects_private_ipv6_notations(url, monkeypatch, requests_mock):
+def test_scrape_rejects_private_ipv6_notations(
+    url, monkeypatch, requests_mock
+):
     """Private and loopback IPv6 alternative notations are blocked."""
     monkeypatch.setattr(
         "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
@@ -58,9 +58,27 @@ def _private_dns_addrinfo(*_, **__):
     ]
 
 
+def test_scrape_rejects_disallowed_scrape_host(monkeypatch, requests_mock):
+    """Hosts outside the allowlist are rejected before network access."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"www.ocado.com", "good.example.com"},
+    )
+
+    with pytest.raises(ValueError, match="Host not in scraper allowlist"):
+        get_product_nutritional_info_from_url("https://forbidden.example.test")
+
+    assert not requests_mock.called
+
+
 @pytest.mark.parametrize("url", ["https://127.0.0.1", "https://[::1]"])
-def test_scrape_rejects_private_hosts(url, requests_mock):
+def test_scrape_rejects_private_hosts(url, monkeypatch, requests_mock):
     """Non-public host literals are blocked."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"127.0.0.1", "::1"},
+    )
+
     with pytest.raises(ValueError, match="Disallowed"):
         get_product_nutritional_info_from_url(url)
 
@@ -74,8 +92,13 @@ def test_scrape_rejects_private_hosts(url, requests_mock):
         "https://[fd00::1]",
     ],
 )
-def test_scrape_rejects_private_ipv6_notations(url, requests_mock):
+def test_scrape_rejects_private_ipv6_notations(url, monkeypatch, requests_mock):
     """Private and loopback IPv6 alternative notations are blocked."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"::ffff:7f00:1", "fd00::1"},
+    )
+
     with pytest.raises(ValueError, match="Disallowed"):
         get_product_nutritional_info_from_url(url)
 
@@ -87,6 +110,10 @@ def test_scrape_rejects_dns_private_host(monkeypatch, requests_mock):
     monkeypatch.setattr(
         "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
         _private_dns_addrinfo,
+    )
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"private.example.test"},
     )
 
     with pytest.raises(ValueError, match="Disallowed resolved IP"):
@@ -101,11 +128,15 @@ def test_scrape_rejects_private_redirect_target(monkeypatch, requests_mock):
         "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
         _mixed_addrinfo,
     )
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"good.example.com", "private.example.test"},
+    )
 
     requests_mock.get(
         "https://good.example.com/page",
         status_code=302,
-        headers={"Location": "https://169.254.169.254/"},
+        headers={"Location": "https://private.example.test/"},
     )
 
     with pytest.raises(ValueError, match="Disallowed resolved IP"):
@@ -119,14 +150,29 @@ def test_scrape_rejects_private_ipv6_redirect_target(
 ):
     """Private IPv6 redirect targets are rejected."""
     monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"good.example.com", "private6.example.test"},
+    )
+
+    monkeypatch.setattr(
         "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
-        _mixed_addrinfo,
+        lambda *args, **kwargs: (
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("fe80::1", 443),
+            )
+            if args[0] == "private6.example.test"
+            else _mixed_addrinfo(*args, **kwargs)
+        ),
     )
 
     requests_mock.get(
         "https://good.example.com/page",
         status_code=302,
-        headers={"Location": "https://[fe80::1]/"},
+        headers={"Location": "https://private6.example.test/"},
     )
 
     with pytest.raises(ValueError, match="Disallowed resolved IP"):
@@ -140,6 +186,10 @@ def test_scrape_rejects_redirect_to_different_host(monkeypatch, requests_mock):
     monkeypatch.setattr(
         "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
         _public_addrinfo,
+    )
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"good.example.com", "other.example.com"},
     )
 
     requests_mock.get(

--- a/platform/k8s/base/backend.yaml
+++ b/platform/k8s/base/backend.yaml
@@ -40,16 +40,16 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /admin/login/
+              path: /healthz/
               port: 8080
             initialDelaySeconds: 15
           readinessProbe:
             httpGet:
-              path: /admin/login/
+              path: /healthz/
               port: 8080
           startupProbe:
             httpGet:
-              path: /admin/login/
+              path: /healthz/
               port: 8080
             initialDelaySeconds: 15
             failureThreshold: 600


### PR DESCRIPTION
## Summary
- Add SSRF/unbounded-fetch hardening in apps.foods.nutrition_facts_finder: strict URL validation (HTTPS-only, no credentials), hostname resolution checks for public-only addresses, redirect follow limit, response content-type allowlist, streamed size caps, and request timeout handling.
- Propagate fetch validation failures into admin form validation as user-facing validation errors.
- Make Django security settings production-aware via ENVIRONMENT, with secure-cookie/redirect/HSTS defaults and proxy SSL header defaults.
- Update README with production-like security configuration guidance using placeholders only.
- Add regression tests for security headers, deploy checks, and scraper hardening cases (private hosts, private DNS, private redirect targets, redirect loops, oversized responses).

## Checks
- cd backend && uv run pytest --no-cov tests/config/test_security.py tests/foods/nutrition_facts_finder/test_scrape_ocado.py tests/foods/nutrition_facts_finder/test_scrape_security.py
- cd backend && uv run flake8 apps/foods/nutrition_facts_finder.py apps/foods/admin/product.py config/settings.py tests/config/test_security.py tests/foods/nutrition_facts_finder/test_scrape_security.py tests/foods/nutrition_facts_finder/test_scrape_ocado.py
- cd backend && SECRET_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa GEMINI_API_KEY=ci-key DATABASE_URL=sqlite:////tmp/nutrition_test.db DJANGO_SETTINGS_MODULE=config.settings uv run mypy apps/foods/nutrition_facts_finder.py apps/foods/admin/product.py
- cd backend && SECRET_KEY='local-production-deploy-check-key-0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ' GEMINI_API_KEY=ci-key DATABASE_URL=sqlite:////tmp/nutrition_test.db ENVIRONMENT=production DEBUG=False ALLOWED_HOSTS=localhost,example.com CSRF_TRUSTED_ORIGINS=https://localhost,https://example.com SECURE_HSTS_PRELOAD=True uv run python manage.py check --deploy

Closes #376
Closes #377