### PR TITLE
security: patch vulnerable locked runtime deps and add audit gates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,8 +235,10 @@ jobs:
       - run:
           name: Run Frontend Production Dependency Audit
           command: |
+            set +e
             npm audit --omit=dev --audit-level=high --json > /tmp/npm-audit-report.json
             AUDIT_EXIT_CODE=$?
+            set -e
             python3 ../.circleci/scripts/check_frontend_dependency_audit.py \
               --audit-report /tmp/npm-audit-report.json \
               --allowlist ../.circleci/dependency-audit-npm-allowlist.txt \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ jobs:
           command: |
             npm audit --omit=dev --audit-level=high --json > /tmp/npm-audit-report.json
             AUDIT_EXIT_CODE=$?
-            python3 .circleci/scripts/check_frontend_dependency_audit.py \
+            python3 ../.circleci/scripts/check_frontend_dependency_audit.py \
               --audit-report /tmp/npm-audit-report.json \
               --allowlist ../.circleci/dependency-audit-npm-allowlist.txt \
               --exit-code "$AUDIT_EXIT_CODE"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,56 @@ jobs:
           name: Run Frontend Type Check
           command: npx tsc --noEmit --ignoreDeprecations 6.0
 
+  backend-dependency-audit:
+    working_directory: ~/project/backend
+    executor: python
+    steps:
+      - python-dependencies
+      - run:
+          name: Export Production Backend Lockfile
+          command: |
+            uv export --format requirements-txt --no-hashes --no-dev > /tmp/backend-production-requirements.txt
+      - run:
+          name: Run Backend Production Dependency Audit
+          command: |
+            IGNORE_ARGS=""
+            if [ -f ../.circleci/dependency-audit-pip-allowlist.txt ]; then
+              while IFS= read -r vuln_id; do
+                case "$vuln_id" in
+                  ""|\#*)
+                    continue
+                    ;;
+                esac
+                IGNORE_ARGS="$IGNORE_ARGS --ignore-vuln $vuln_id"
+              done < ../.circleci/dependency-audit-pip-allowlist.txt
+            fi
+
+            uvx --from pip-audit pip-audit \
+              -r /tmp/backend-production-requirements.txt \
+              --no-deps \
+              --disable-pip \
+              $IGNORE_ARGS
+
+  webapp-dependency-audit:
+    working_directory: ~/project/webapp
+    docker:
+      - image: cimg/node:22.12.0
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Install Frontend Dependencies
+          command: npm ci
+      - run:
+          name: Run Frontend Production Dependency Audit
+          command: |
+            npm audit --omit=dev --audit-level=high --json > /tmp/npm-audit-report.json
+            AUDIT_EXIT_CODE=$?
+            python3 .circleci/scripts/check_frontend_dependency_audit.py \
+              --audit-report /tmp/npm-audit-report.json \
+              --allowlist ../.circleci/dependency-audit-npm-allowlist.txt \
+              --exit-code "$AUDIT_EXIT_CODE"
+
   backend-docker-build-tag-push:
     working_directory: ~/project/backend
     docker:
@@ -416,6 +466,8 @@ workflows:
       - pylint-tests
       - pydocstyle
       - pydocstyle-tests
+      - backend-dependency-audit
+      - webapp-dependency-audit
       - webapp-checks
       - backend-docker-build-tag-push:
           context:
@@ -430,11 +482,13 @@ workflows:
             - pylint-tests
             - pydocstyle
             - pydocstyle-tests
+            - backend-dependency-audit
       - webapp-docker-build-tag-push:
           context:
             - Docker
           requires:
             - webapp-checks
+            - webapp-dependency-audit
       - deploy-preview:
           context:
             - kubeconfig

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,12 +235,52 @@ jobs:
       - run:
           name: Run Frontend Production Dependency Audit
           command: |
+<<<<<<< HEAD
             npm audit --omit=dev --audit-level=high --json > /tmp/npm-audit-report.json
             AUDIT_EXIT_CODE=$?
             python3 .circleci/scripts/check_frontend_dependency_audit.py \
               --audit-report /tmp/npm-audit-report.json \
               --allowlist ../.circleci/dependency-audit-npm-allowlist.txt \
               --exit-code "$AUDIT_EXIT_CODE"
+=======
+            npm audit --omit=dev --audit-level=high --json > /tmp/npm-audit-report.json || true
+            python3 - \<<'PY'
+            import json
+            import re
+
+            report = json.load(open("/tmp/npm-audit-report.json"))
+            allowlist = set()
+            with open("../.circleci/dependency-audit-npm-allowlist.txt", "r", encoding="utf-8") as handle:
+              for line in handle:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                  allowlist.add(line)
+
+            advisories = set()
+            metadata = report.get("metadata", {}).get("vulnerabilities", {})
+            if metadata.get("high", 0) == 0 and metadata.get("critical", 0) == 0:
+              print("Frontend production dependency audit passed with no high/critical vulnerabilities.")
+              raise SystemExit(0)
+
+            for name, detail in report.get("vulnerabilities", {}).items():
+              if not isinstance(detail, dict):
+                continue
+              severity = str(detail.get("severity", "")).lower()
+              if severity not in {"high", "critical"}:
+                continue
+              advisory_ids = set(re.findall(r"(GHSA-[A-Za-z0-9-]+|CVE-\d{4}-\d+)", json.dumps(detail)))
+              advisory_ids.add(name)
+              advisories.update(advisory_ids - allowlist)
+
+            if advisories:
+              print("Frontend production dependency audit failed due to unwaived high/critical vulnerabilities:")
+              for advisory in sorted(advisories):
+                print(f"  - {advisory}")
+              raise SystemExit(1)
+
+            print("Frontend production dependency audit passed with only allowlisted high/critical vulnerabilities.")
+            PY
+>>>>>>> 9e0c7c6 (Fix CircleCI heredoc escaping for config parser)
 
   backend-docker-build-tag-push:
     working_directory: ~/project/backend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,52 +235,12 @@ jobs:
       - run:
           name: Run Frontend Production Dependency Audit
           command: |
-<<<<<<< HEAD
             npm audit --omit=dev --audit-level=high --json > /tmp/npm-audit-report.json
             AUDIT_EXIT_CODE=$?
             python3 .circleci/scripts/check_frontend_dependency_audit.py \
               --audit-report /tmp/npm-audit-report.json \
               --allowlist ../.circleci/dependency-audit-npm-allowlist.txt \
               --exit-code "$AUDIT_EXIT_CODE"
-=======
-            npm audit --omit=dev --audit-level=high --json > /tmp/npm-audit-report.json || true
-            python3 - \<<'PY'
-            import json
-            import re
-
-            report = json.load(open("/tmp/npm-audit-report.json"))
-            allowlist = set()
-            with open("../.circleci/dependency-audit-npm-allowlist.txt", "r", encoding="utf-8") as handle:
-              for line in handle:
-                line = line.strip()
-                if line and not line.startswith("#"):
-                  allowlist.add(line)
-
-            advisories = set()
-            metadata = report.get("metadata", {}).get("vulnerabilities", {})
-            if metadata.get("high", 0) == 0 and metadata.get("critical", 0) == 0:
-              print("Frontend production dependency audit passed with no high/critical vulnerabilities.")
-              raise SystemExit(0)
-
-            for name, detail in report.get("vulnerabilities", {}).items():
-              if not isinstance(detail, dict):
-                continue
-              severity = str(detail.get("severity", "")).lower()
-              if severity not in {"high", "critical"}:
-                continue
-              advisory_ids = set(re.findall(r"(GHSA-[A-Za-z0-9-]+|CVE-\d{4}-\d+)", json.dumps(detail)))
-              advisory_ids.add(name)
-              advisories.update(advisory_ids - allowlist)
-
-            if advisories:
-              print("Frontend production dependency audit failed due to unwaived high/critical vulnerabilities:")
-              for advisory in sorted(advisories):
-                print(f"  - {advisory}")
-              raise SystemExit(1)
-
-            print("Frontend production dependency audit passed with only allowlisted high/critical vulnerabilities.")
-            PY
->>>>>>> 9e0c7c6 (Fix CircleCI heredoc escaping for config parser)
 
   backend-docker-build-tag-push:
     working_directory: ~/project/backend

--- a/.circleci/dependency-audit-npm-allowlist.txt
+++ b/.circleci/dependency-audit-npm-allowlist.txt
@@ -1,0 +1,3 @@
+# Temporary vulnerability waivers (frontend, production audit gate).
+# Add one vulnerability ID per line (GHSA-xxxx-... or CVE-xxxx-xxxx)
+# Include owner and removal date in the PR description before merging.

--- a/.circleci/dependency-audit-pip-allowlist.txt
+++ b/.circleci/dependency-audit-pip-allowlist.txt
@@ -1,0 +1,3 @@
+# Temporary vulnerability waivers (backend) for production audit gates.
+# Add one vulnerability ID per line and include owner/date justification in the PR.
+# Remove each entry as soon as a patched dependency is merged.

--- a/.circleci/scripts/check_frontend_dependency_audit.py
+++ b/.circleci/scripts/check_frontend_dependency_audit.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-return-doc
 """CircleCI helper used by the frontend npm audit gate."""
 
 from __future__ import annotations
@@ -13,6 +14,14 @@ ADVISORY_ID_RE = re.compile(r"(GHSA-[A-Za-z0-9-]+|CVE-\d{4}-\d+)")
 
 
 def _load_allowlist(path: Path) -> set[str]:
+    """Load allowlist entries from a text file.
+
+    Args:
+        path: Path to a newline-separated allowlist file.
+
+    Returns:
+        A set of advisory identifiers and package names that are waived.
+    """
     allowlist: set[str] = set()
     if not path.exists():
         return allowlist
@@ -25,6 +34,7 @@ def _load_allowlist(path: Path) -> set[str]:
 
 
 def _extract_advisory_ids(vulnerability: dict[str, object]) -> set[str]:
+    """Extract all advisory identifiers from a single vulnerability payload."""
     advisory_ids: set[str] = set()
     details = [json.dumps(vulnerability)]
 
@@ -48,19 +58,25 @@ def _extract_advisory_ids(vulnerability: dict[str, object]) -> set[str]:
 
 
 def _load_audit_report(path: Path) -> object:
+    """Load and parse the `npm audit` JSON report."""
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except OSError as exc:
         raise ValueError(f"Unable to read npm audit report at {path}") from exc
     except json.JSONDecodeError as exc:
-        raise ValueError(f"Invalid JSON in npm audit report at {path}") from exc
+        raise ValueError(
+            f"Invalid JSON in npm audit report at {path}"
+        ) from exc
 
 
 def _validate_and_extract(
     report: object,
 ) -> tuple[dict[str, object], dict[str, int]]:
+    """Validate required keys in the `npm audit` JSON structure."""
     if not isinstance(report, dict):
-        raise ValueError("Invalid npm audit schema: expected top-level JSON object.")
+        raise ValueError(
+            "Invalid npm audit schema: expected top-level JSON object."
+        )
 
     if "error" in report:
         payload = report.get("error")
@@ -75,7 +91,8 @@ def _validate_and_extract(
     vulnerabilities = report.get("vulnerabilities")
     if not isinstance(vulnerabilities, dict):
         raise ValueError(
-            "Invalid npm audit schema: missing or invalid top-level 'vulnerabilities' object."
+            "Invalid npm audit schema: missing or invalid top-level "
+            "'vulnerabilities' object."
         )
 
     metadata = report.get("metadata")
@@ -92,10 +109,26 @@ def evaluate_frontend_audit(
     allowlist: set[str],
     audit_exit_code: int,
 ) -> int:
+    """Evaluate npm audit findings and return the required script exit code.
+
+    The function fails closed when input data is invalid, when npm exits with an
+    unexpected status, or when unwaived high/critical vulnerabilities remain.
+
+    Args:
+        report: Parsed npm audit JSON payload.
+        allowlist: Advisory/package IDs allowed to fail.
+        audit_exit_code: Exit code emitted by npm audit.
+
+    Returns:
+        0 when the audit pass condition is satisfied, otherwise 1.
+    """
     try:
         vulnerabilities, _ = _validate_and_extract(report)
     except ValueError as exc:
-        print(f"Frontend production dependency audit failed: {exc}", file=sys.stderr)
+        print(
+            f"Frontend production dependency audit failed: {exc}",
+            file=sys.stderr,
+        )
         return 1
 
     unwaived_advisories: set[str] = set()
@@ -111,17 +144,18 @@ def evaluate_frontend_audit(
         ids = _extract_advisory_ids(vulnerability)
         unwaived_advisories.update(ids.difference(allowlist))
 
-    if audit_exit_code != 0 and audit_exit_code != 1:
+    if audit_exit_code not in (0, 1):
         print(
-            "Frontend production dependency audit failed: non-vulnerability npm exit code "
-            f"{audit_exit_code}.",
+            "Frontend production dependency audit failed: non-vulnerability "
+            f"npm exit code {audit_exit_code}.",
             file=sys.stderr,
         )
         return 1
 
     if unwaived_advisories:
         print(
-            "Frontend production dependency audit failed due to unwaived high/critical vulnerabilities:"
+            "Frontend production dependency audit failed due to unwaived "
+            "high/critical vulnerabilities:"
         )
         for advisory in sorted(unwaived_advisories):
             print(f"  - {advisory}")
@@ -129,14 +163,19 @@ def evaluate_frontend_audit(
 
     if audit_exit_code == 1:
         print(
-            "Frontend production dependency audit passed with only allowlisted high/critical vulnerabilities."
+            "Frontend production dependency audit passed with only "
+            "allowlisted high/critical vulnerabilities."
         )
     else:
-        print("Frontend production dependency audit passed with no high/critical vulnerabilities.")
+        print(
+            "Frontend production dependency audit passed with no high/"
+            "critical vulnerabilities."
+        )
     return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the command line parser for audit enforcement."""
     parser = argparse.ArgumentParser(
         description="Evaluate frontend npm audit output with waiver allowlist."
     )
@@ -146,7 +185,15 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: list[str] | None = None) -> int:  # pylint: disable=W9011
+    """Run audit evaluation CLI and return exit status.
+
+    Args:
+        argv: Optional list of CLI arguments.
+
+    Returns:
+        int: Script exit status.
+    """
     parser = build_parser()
     args = parser.parse_args(argv)
 
@@ -155,7 +202,10 @@ def main(argv: list[str] | None = None) -> int:
         allowlist = _load_allowlist(args.allowlist)
         return evaluate_frontend_audit(report, allowlist, args.exit_code)
     except ValueError as exc:
-        print(f"Frontend production dependency audit failed: {exc}", file=sys.stderr)
+        print(
+            f"Frontend production dependency audit failed: {exc}",
+            file=sys.stderr,
+        )
         return 1
 
 

--- a/.circleci/scripts/check_frontend_dependency_audit.py
+++ b/.circleci/scripts/check_frontend_dependency_audit.py
@@ -8,7 +8,6 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Iterable
 
 ADVISORY_ID_RE = re.compile(r"(GHSA-[A-Za-z0-9-]+|CVE-\d{4}-\d+)")
 
@@ -93,7 +92,12 @@ def evaluate_frontend_audit(
     allowlist: set[str],
     audit_exit_code: int,
 ) -> int:
-    vulnerabilities, _metadata = _validate_and_extract(report)
+    try:
+        vulnerabilities, _ = _validate_and_extract(report)
+    except ValueError as exc:
+        print(f"Frontend production dependency audit failed: {exc}", file=sys.stderr)
+        return 1
+
     unwaived_advisories: set[str] = set()
 
     for vulnerability in vulnerabilities.values():

--- a/.circleci/scripts/check_frontend_dependency_audit.py
+++ b/.circleci/scripts/check_frontend_dependency_audit.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""CircleCI helper used by the frontend npm audit gate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+ADVISORY_ID_RE = re.compile(r"(GHSA-[A-Za-z0-9-]+|CVE-\d{4}-\d+)")
+
+
+def _load_allowlist(path: Path) -> set[str]:
+    allowlist: set[str] = set()
+    if not path.exists():
+        return allowlist
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        item = line.strip()
+        if item and not item.startswith("#"):
+            allowlist.add(item)
+    return allowlist
+
+
+def _extract_advisory_ids(vulnerability: dict[str, object]) -> set[str]:
+    advisory_ids: set[str] = set()
+    details = [json.dumps(vulnerability)]
+
+    via = vulnerability.get("via")
+    if isinstance(via, list):
+        for entry in via:
+            if isinstance(entry, str):
+                details.append(entry)
+            elif isinstance(entry, dict):
+                details.append(json.dumps(entry))
+
+    for detail in details:
+        advisory_ids.update(ADVISORY_ID_RE.findall(detail))
+
+    if not advisory_ids:
+        package_name = vulnerability.get("name")
+        if isinstance(package_name, str) and package_name:
+            advisory_ids.add(package_name)
+
+    return advisory_ids
+
+
+def _load_audit_report(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"Unable to read npm audit report at {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in npm audit report at {path}") from exc
+
+
+def _validate_and_extract(
+    report: object,
+) -> tuple[dict[str, object], dict[str, int]]:
+    if not isinstance(report, dict):
+        raise ValueError("Invalid npm audit schema: expected top-level JSON object.")
+
+    if "error" in report:
+        payload = report.get("error")
+        if isinstance(payload, str):
+            message = payload
+        elif isinstance(payload, dict) and "summary" in payload:
+            message = str(payload["summary"])
+        else:
+            message = str(payload)
+        raise ValueError(f"npm audit reported an error: {message}")
+
+    vulnerabilities = report.get("vulnerabilities")
+    if not isinstance(vulnerabilities, dict):
+        raise ValueError(
+            "Invalid npm audit schema: missing or invalid top-level 'vulnerabilities' object."
+        )
+
+    metadata = report.get("metadata")
+    if not isinstance(metadata, dict):
+        raise ValueError(
+            "Invalid npm audit schema: missing or invalid top-level 'metadata' object."
+        )
+
+    return vulnerabilities, metadata
+
+
+def evaluate_frontend_audit(
+    report: object,
+    allowlist: set[str],
+    audit_exit_code: int,
+) -> int:
+    vulnerabilities, _metadata = _validate_and_extract(report)
+    unwaived_advisories: set[str] = set()
+
+    for vulnerability in vulnerabilities.values():
+        if not isinstance(vulnerability, dict):
+            continue
+
+        severity = str(vulnerability.get("severity", "")).lower()
+        if severity not in {"high", "critical"}:
+            continue
+
+        ids = _extract_advisory_ids(vulnerability)
+        unwaived_advisories.update(ids.difference(allowlist))
+
+    if audit_exit_code != 0 and audit_exit_code != 1:
+        print(
+            "Frontend production dependency audit failed: non-vulnerability npm exit code "
+            f"{audit_exit_code}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if unwaived_advisories:
+        print(
+            "Frontend production dependency audit failed due to unwaived high/critical vulnerabilities:"
+        )
+        for advisory in sorted(unwaived_advisories):
+            print(f"  - {advisory}")
+        return 1
+
+    if audit_exit_code == 1:
+        print(
+            "Frontend production dependency audit passed with only allowlisted high/critical vulnerabilities."
+        )
+    else:
+        print("Frontend production dependency audit passed with no high/critical vulnerabilities.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Evaluate frontend npm audit output with waiver allowlist."
+    )
+    parser.add_argument("--audit-report", type=Path, required=True)
+    parser.add_argument("--allowlist", type=Path, required=True)
+    parser.add_argument("--exit-code", type=int, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        report = _load_audit_report(args.audit_report)
+        allowlist = _load_allowlist(args.allowlist)
+        return evaluate_frontend_audit(report, allowlist, args.exit_code)
+    except ValueError as exc:
+        print(f"Frontend production dependency audit failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.circleci/scripts/check_frontend_dependency_audit.py
+++ b/.circleci/scripts/check_frontend_dependency_audit.py
@@ -140,7 +140,14 @@ def evaluate_frontend_audit(
             unwaived_advisories.add(UNIDENTIFIED_VULNERABILITY_LABEL)
             continue
 
-        severity = str(vulnerability.get("severity", "")).lower()
+        severity = vulnerability.get("severity")
+        if not isinstance(severity, str) or not severity.strip():
+            # Missing, empty, or non-string severity is malformed input:
+            # treat it as unidentified (fail closed) so it cannot slip
+            # through the gate without scrutiny.
+            unwaived_advisories.add(UNIDENTIFIED_VULNERABILITY_LABEL)
+            continue
+        severity = severity.strip().lower()
         if severity not in {"high", "critical"}:
             continue
 

--- a/.circleci/scripts/check_frontend_dependency_audit.py
+++ b/.circleci/scripts/check_frontend_dependency_audit.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 ADVISORY_ID_RE = re.compile(r"(GHSA-[A-Za-z0-9-]+|CVE-\d{4}-\d+)")
 
+UNIDENTIFIED_VULNERABILITY_LABEL = "<unidentified high/critical vulnerability>"
+
 
 def _load_allowlist(path: Path) -> set[str]:
     """Load allowlist entries from a text file.
@@ -135,6 +137,7 @@ def evaluate_frontend_audit(
 
     for vulnerability in vulnerabilities.values():
         if not isinstance(vulnerability, dict):
+            unwaived_advisories.add(UNIDENTIFIED_VULNERABILITY_LABEL)
             continue
 
         severity = str(vulnerability.get("severity", "")).lower()
@@ -142,6 +145,9 @@ def evaluate_frontend_audit(
             continue
 
         ids = _extract_advisory_ids(vulnerability)
+        if not ids:
+            unwaived_advisories.add(UNIDENTIFIED_VULNERABILITY_LABEL)
+            continue
         unwaived_advisories.update(ids.difference(allowlist))
 
     if audit_exit_code not in (0, 1):

--- a/.circleci/scripts/test_check_frontend_dependency_audit.py
+++ b/.circleci/scripts/test_check_frontend_dependency_audit.py
@@ -18,14 +18,12 @@ def _run(
 ) -> int:
     """Write temporary inputs and run the audit parser CLI.
 
-    Args:
-        tmp_path: Temporary directory fixture path.
-        report: JSON payload to write into the temporary report file.
-        allowlist: List of waiver identifiers.
-        exit_code: Simulated `npm audit` exit code.
+    :param tmp_path: Temporary directory fixture path.
+    :param report: JSON payload to write into the temporary report file.
+    :param allowlist: List of waiver identifiers.
+    :param exit_code: Simulated `npm audit` exit code.
 
-    Returns:
-        The parser CLI exit status.
+    :return: The parser CLI exit status.
     """
     report_path = tmp_path / "npm-audit-report.json"
     allowlist_path = tmp_path / "allowlist.txt"
@@ -93,8 +91,14 @@ def test_clean_report_passes(tmp_path: Path) -> None:
         raise AssertionError("Expected audit exit code 0")
 
 
-def test_clean_report_non_vulnerability_failure_status_fails(tmp_path: Path) -> None:
-    """A clean report with non-vulnerability exit code must still fail."""
+def test_clean_report_non_vulnerability_failure_status_fails(
+    tmp_path: Path,
+) -> None:
+    """A clean report with non-vulnerability exit code must still fail.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
     exit_code = _run(
         tmp_path,
         {

--- a/.circleci/scripts/test_check_frontend_dependency_audit.py
+++ b/.circleci/scripts/test_check_frontend_dependency_audit.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 import check_frontend_dependency_audit as audit_parser
 
 
@@ -312,6 +314,37 @@ def test_non_dict_vulnerability_entry_fails(tmp_path: Path) -> None:
         {
             "auditReportVersion": 3,
             "vulnerabilities": {"x": "oops"},
+            "metadata": {"vulnerabilities": {"high": 1, "critical": 0}},
+        },
+        [],
+        exit_code=1,
+    )
+    if exit_code != 1:
+        raise AssertionError("Expected audit exit code 1")
+
+
+@pytest.mark.parametrize("severity", [None, "", "  ", 5, ["high"]])
+def test_malformed_severity_entry_fails(
+    tmp_path: Path, severity: object
+) -> None:
+    """Entries with missing/empty/non-string severity must fail closed.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+        severity: Malformed severity value to exercise.
+    """
+    entry: dict[str, object] = {
+        "severity": severity,
+        "via": ["GHSA-aaaa-bbbb-cccc"],
+        "name": "lodash",
+    }
+    if severity is None:
+        entry.pop("severity")
+    exit_code = _run(
+        tmp_path,
+        {
+            "auditReportVersion": 3,
+            "vulnerabilities": {"lodash": entry},
             "metadata": {"vulnerabilities": {"high": 1, "critical": 0}},
         },
         [],

--- a/.circleci/scripts/test_check_frontend_dependency_audit.py
+++ b/.circleci/scripts/test_check_frontend_dependency_audit.py
@@ -1,0 +1,177 @@
+"""Tests for the frontend npm audit checker helper."""
+
+import json
+from pathlib import Path
+
+from check_frontend_dependency_audit import _load_allowlist, evaluate_frontend_audit, _load_audit_report
+
+
+def _run(tmp_path: Path, report: object, allowlist: list[str], exit_code: int = 1) -> int:
+    report_path = tmp_path / "npm-audit-report.json"
+    allowlist_path = tmp_path / "allowlist.txt"
+
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+    allowlist_path.write_text("\n".join(allowlist), encoding="utf-8")
+
+    return evaluate_frontend_audit(
+        _load_audit_report(report_path),
+        _load_allowlist(allowlist_path),
+        exit_code,
+    )
+
+
+def test_transport_error_payload_fails(tmp_path: Path):
+    exit_code = _run(
+        tmp_path,
+        {"error": "ENOTFOUND: Unable to reach registry"},
+        [],
+        exit_code=1,
+    )
+    assert exit_code == 1
+
+
+def test_invalid_schema_fails(tmp_path: Path):
+    exit_code = _run(tmp_path, [], [], exit_code=0)
+    assert exit_code == 1
+
+
+def test_clean_report_passes(tmp_path: Path):
+    exit_code = _run(
+        tmp_path,
+        {
+            "auditReportVersion": 3,
+            "vulnerabilities": {},
+            "metadata": {"vulnerabilities": {"high": 0, "critical": 0}},
+        },
+        [],
+        exit_code=0,
+    )
+    assert exit_code == 0
+
+
+def test_unwaived_high_or_critical_report_fails(tmp_path: Path):
+    exit_code = _run(
+        tmp_path,
+        {
+            "auditReportVersion": 3,
+            "vulnerabilities": {
+                "lodash": {
+                    "name": "lodash",
+                    "severity": "high",
+                    "isDirect": True,
+                    "via": ["GHSA-xxxx-yyyy-zzzz"],
+                }
+            },
+            "metadata": {"vulnerabilities": {"high": 1, "critical": 0}},
+        },
+        [],
+        exit_code=1,
+    )
+    assert exit_code == 1
+
+
+def test_all_issues_waived_when_status_one_passes(tmp_path: Path):
+    exit_code = _run(
+        tmp_path,
+        {
+            "auditReportVersion": 3,
+            "vulnerabilities": {
+                "lodash": {
+                    "name": "lodash",
+                    "severity": "high",
+                    "isDirect": True,
+                    "via": ["GHSA-xxxx-yyyy-zzzz"],
+                }
+            },
+            "metadata": {"vulnerabilities": {"high": 1, "critical": 0}},
+        },
+        ["GHSA-xxxx-yyyy-zzzz"],
+        exit_code=1,
+    )
+    assert exit_code == 0
+
+
+def test_partial_waiver_fails(tmp_path: Path):
+    exit_code = _run(
+        tmp_path,
+        {
+            "auditReportVersion": 3,
+            "vulnerabilities": {
+                "package-a": {
+                    "name": "package-a",
+                    "severity": "high",
+                    "via": ["GHSA-aaa-bbbb-cccc"],
+                },
+                "package-b": {
+                    "name": "package-b",
+                    "severity": "critical",
+                    "via": ["GHSA-ddd-eeee-ffff"],
+                },
+            },
+            "metadata": {"vulnerabilities": {"high": 1, "critical": 1}},
+        },
+        ["GHSA-aaa-bbbb-cccc"],
+        exit_code=1,
+    )
+    assert exit_code == 1
+
+
+def test_indirect_vulnerability_is_evaluated(tmp_path: Path):
+    exit_code = _run(
+        tmp_path,
+        {
+            "auditReportVersion": 3,
+            "vulnerabilities": {
+                "indirect-vuln": {
+                    "name": "indirect-vuln",
+                    "severity": "critical",
+                    "isDirect": False,
+                    "via": ["GHSA-indirect-aaaa-bbbb-cccc"],
+                }
+            },
+            "metadata": {"vulnerabilities": {"high": 0, "critical": 1}},
+        },
+        ["GHSA-indirect-aaaa-bbbb-cccc"],
+        exit_code=1,
+    )
+    assert exit_code == 0
+
+
+def test_no_identifier_uses_package_name_fallback(tmp_path: Path):
+    exit_code = _run(
+        tmp_path,
+        {
+            "auditReportVersion": 3,
+            "vulnerabilities": {
+                "legacy-pkg": {
+                    "name": "legacy-pkg",
+                    "severity": "high",
+                    "via": [],
+                }
+            },
+            "metadata": {"vulnerabilities": {"high": 1, "critical": 0}},
+        },
+        ["legacy-pkg"],
+        exit_code=1,
+    )
+    assert exit_code == 0
+
+
+def test_non_vulnerability_nonzero_status_fails(tmp_path: Path):
+    exit_code = _run(
+        tmp_path,
+        {
+            "auditReportVersion": 3,
+            "vulnerabilities": {
+                "lodash": {
+                    "name": "lodash",
+                    "severity": "high",
+                    "via": ["GHSA-xxxx-yyyy-zzzz"],
+                }
+            },
+            "metadata": {"vulnerabilities": {"high": 1, "critical": 0}},
+        },
+        [],
+        exit_code=2,
+    )
+    assert exit_code == 1

--- a/.circleci/scripts/test_check_frontend_dependency_audit.py
+++ b/.circleci/scripts/test_check_frontend_dependency_audit.py
@@ -275,3 +275,135 @@ def test_non_vulnerability_nonzero_status_fails(tmp_path: Path) -> None:
     )
     if exit_code != 1:
         raise AssertionError("Expected audit exit code 1")
+
+
+def test_high_critical_entry_without_identifier_fails(tmp_path: Path) -> None:
+    """High/critical entries with no extractable ID must fail closed.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
+    exit_code = _run(
+        tmp_path,
+        {
+            "auditReportVersion": 3,
+            "vulnerabilities": {
+                "broken-entry": {
+                    "severity": "critical",
+                }
+            },
+            "metadata": {"vulnerabilities": {"high": 0, "critical": 1}},
+        },
+        ["broken-entry"],
+        exit_code=1,
+    )
+    if exit_code != 1:
+        raise AssertionError("Expected audit exit code 1")
+
+
+def test_non_dict_vulnerability_entry_fails(tmp_path: Path) -> None:
+    """Malformed non-dict vulnerability entries must fail closed.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
+    exit_code = _run(
+        tmp_path,
+        {
+            "auditReportVersion": 3,
+            "vulnerabilities": {"x": "oops"},
+            "metadata": {"vulnerabilities": {"high": 1, "critical": 0}},
+        },
+        [],
+        exit_code=1,
+    )
+    if exit_code != 1:
+        raise AssertionError("Expected audit exit code 1")
+
+
+def test_allowlist_comment_lines_are_tolerated(tmp_path: Path) -> None:
+    """Allowlist comment lines must not affect waiver matching.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
+    report_path = tmp_path / "npm-audit-report.json"
+    allowlist_path = tmp_path / "allowlist.txt"
+    report_path.write_text(
+        json.dumps(
+            {
+                "auditReportVersion": 3,
+                "vulnerabilities": {
+                    "lodash": {
+                        "name": "lodash",
+                        "severity": "high",
+                        "via": ["GHSA-xxxx-yyyy-zzzz"],
+                    }
+                },
+                "metadata": {"vulnerabilities": {"high": 1, "critical": 0}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    allowlist_path.write_text(
+        "# temporary waiver\nGHSA-xxxx-yyyy-zzzz\n",
+        encoding="utf-8",
+    )
+    result = audit_parser.main(
+        [
+            "--audit-report",
+            str(report_path),
+            "--allowlist",
+            str(allowlist_path),
+            "--exit-code",
+            "1",
+        ]
+    )
+    if result != 0:
+        raise AssertionError("Expected audit exit code 0")
+
+
+def test_invalid_json_report_fails(tmp_path: Path) -> None:
+    """Unparseable audit reports must fail the gate.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
+    report_path = tmp_path / "npm-audit-report.json"
+    allowlist_path = tmp_path / "allowlist.txt"
+    report_path.write_text("{not-json", encoding="utf-8")
+    allowlist_path.write_text("", encoding="utf-8")
+    result = audit_parser.main(
+        [
+            "--audit-report",
+            str(report_path),
+            "--allowlist",
+            str(allowlist_path),
+            "--exit-code",
+            "1",
+        ]
+    )
+    if result != 1:
+        raise AssertionError("Expected audit exit code 1")
+
+
+def test_missing_report_file_fails(tmp_path: Path) -> None:
+    """Missing audit report files must fail the gate.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
+    allowlist_path = tmp_path / "allowlist.txt"
+    allowlist_path.write_text("", encoding="utf-8")
+    result = audit_parser.main(
+        [
+            "--audit-report",
+            str(tmp_path / "does-not-exist.json"),
+            "--allowlist",
+            str(allowlist_path),
+            "--exit-code",
+            "1",
+        ]
+    )
+    if result != 1:
+        raise AssertionError("Expected audit exit code 1")

--- a/.circleci/scripts/test_check_frontend_dependency_audit.py
+++ b/.circleci/scripts/test_check_frontend_dependency_audit.py
@@ -1,41 +1,84 @@
 """Tests for the frontend npm audit checker helper."""
 
+# pylint: disable=missing-raises-doc
+
+from __future__ import annotations
+
 import json
 from pathlib import Path
 
-from check_frontend_dependency_audit import _load_allowlist, evaluate_frontend_audit, _load_audit_report
+import check_frontend_dependency_audit as audit_parser
 
 
-def _run(tmp_path: Path, report: object, allowlist: list[str], exit_code: int = 1) -> int:
+def _run(
+    tmp_path: Path,
+    report: object,
+    allowlist: list[str],
+    exit_code: int = 1,
+) -> int:
+    """Write temporary inputs and run the audit parser CLI.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+        report: JSON payload to write into the temporary report file.
+        allowlist: List of waiver identifiers.
+        exit_code: Simulated `npm audit` exit code.
+
+    Returns:
+        The parser CLI exit status.
+    """
     report_path = tmp_path / "npm-audit-report.json"
     allowlist_path = tmp_path / "allowlist.txt"
 
     report_path.write_text(json.dumps(report), encoding="utf-8")
     allowlist_path.write_text("\n".join(allowlist), encoding="utf-8")
 
-    return evaluate_frontend_audit(
-        _load_audit_report(report_path),
-        _load_allowlist(allowlist_path),
-        exit_code,
+    result = audit_parser.main(
+        [
+            "--audit-report",
+            str(report_path),
+            "--allowlist",
+            str(allowlist_path),
+            "--exit-code",
+            str(exit_code),
+        ]
     )
+    return result
 
 
-def test_transport_error_payload_fails(tmp_path: Path):
+def test_transport_error_payload_fails(tmp_path: Path) -> None:
+    """Transport-level failures must fail audit evaluation.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
     exit_code = _run(
         tmp_path,
         {"error": "ENOTFOUND: Unable to reach registry"},
         [],
         exit_code=1,
     )
-    assert exit_code == 1
+    if exit_code != 1:
+        raise AssertionError("Expected audit exit code 1")
 
 
-def test_invalid_schema_fails(tmp_path: Path):
+def test_invalid_schema_fails(tmp_path: Path) -> None:
+    """Invalid schemas should fail audit evaluation.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
     exit_code = _run(tmp_path, [], [], exit_code=0)
-    assert exit_code == 1
+    if exit_code != 1:
+        raise AssertionError("Expected audit exit code 1")
 
 
-def test_clean_report_passes(tmp_path: Path):
+def test_clean_report_passes(tmp_path: Path) -> None:
+    """A report with no high/critical issues should pass.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
     exit_code = _run(
         tmp_path,
         {
@@ -46,10 +89,16 @@ def test_clean_report_passes(tmp_path: Path):
         [],
         exit_code=0,
     )
-    assert exit_code == 0
+    if exit_code != 0:
+        raise AssertionError("Expected audit exit code 0")
 
 
-def test_unwaived_high_or_critical_report_fails(tmp_path: Path):
+def test_unwaived_high_or_critical_report_fails(tmp_path: Path) -> None:
+    """Unwaived high/critical issues should fail audit evaluation.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
     exit_code = _run(
         tmp_path,
         {
@@ -67,10 +116,16 @@ def test_unwaived_high_or_critical_report_fails(tmp_path: Path):
         [],
         exit_code=1,
     )
-    assert exit_code == 1
+    if exit_code != 1:
+        raise AssertionError("Expected audit exit code 1")
 
 
-def test_all_issues_waived_when_status_one_passes(tmp_path: Path):
+def test_all_issues_waived_when_status_one_passes(tmp_path: Path) -> None:
+    """Waived findings should pass when npm reports high/critical status.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
     exit_code = _run(
         tmp_path,
         {
@@ -88,10 +143,16 @@ def test_all_issues_waived_when_status_one_passes(tmp_path: Path):
         ["GHSA-xxxx-yyyy-zzzz"],
         exit_code=1,
     )
-    assert exit_code == 0
+    if exit_code != 0:
+        raise AssertionError("Expected audit exit code 0")
 
 
-def test_partial_waiver_fails(tmp_path: Path):
+def test_partial_waiver_fails(tmp_path: Path) -> None:
+    """Partially waived findings should still fail.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
     exit_code = _run(
         tmp_path,
         {
@@ -113,10 +174,16 @@ def test_partial_waiver_fails(tmp_path: Path):
         ["GHSA-aaa-bbbb-cccc"],
         exit_code=1,
     )
-    assert exit_code == 1
+    if exit_code != 1:
+        raise AssertionError("Expected audit exit code 1")
 
 
-def test_indirect_vulnerability_is_evaluated(tmp_path: Path):
+def test_indirect_vulnerability_is_evaluated(tmp_path: Path) -> None:
+    """Indirect vulnerabilities must still be evaluated and waivered.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
     exit_code = _run(
         tmp_path,
         {
@@ -134,10 +201,16 @@ def test_indirect_vulnerability_is_evaluated(tmp_path: Path):
         ["GHSA-indirect-aaaa-bbbb-cccc"],
         exit_code=1,
     )
-    assert exit_code == 0
+    if exit_code != 0:
+        raise AssertionError("Expected audit exit code 0")
 
 
-def test_no_identifier_uses_package_name_fallback(tmp_path: Path):
+def test_no_identifier_uses_package_name_fallback(tmp_path: Path) -> None:
+    """Fallback to package name should apply when advisories are missing.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
     exit_code = _run(
         tmp_path,
         {
@@ -154,10 +227,16 @@ def test_no_identifier_uses_package_name_fallback(tmp_path: Path):
         ["legacy-pkg"],
         exit_code=1,
     )
-    assert exit_code == 0
+    if exit_code != 0:
+        raise AssertionError("Expected audit exit code 0")
 
 
-def test_non_vulnerability_nonzero_status_fails(tmp_path: Path):
+def test_non_vulnerability_nonzero_status_fails(tmp_path: Path) -> None:
+    """Non-vulnerability nonzero npm exit codes must fail the gate.
+
+    Args:
+        tmp_path: Temporary directory fixture path.
+    """
     exit_code = _run(
         tmp_path,
         {
@@ -174,4 +253,5 @@ def test_non_vulnerability_nonzero_status_fails(tmp_path: Path):
         [],
         exit_code=2,
     )
-    assert exit_code == 1
+    if exit_code != 1:
+        raise AssertionError("Expected audit exit code 1")

--- a/.circleci/scripts/test_check_frontend_dependency_audit.py
+++ b/.circleci/scripts/test_check_frontend_dependency_audit.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 import check_frontend_dependency_audit as audit_parser
+import pytest
 
 
 def _run(

--- a/.circleci/scripts/test_check_frontend_dependency_audit.py
+++ b/.circleci/scripts/test_check_frontend_dependency_audit.py
@@ -93,6 +93,22 @@ def test_clean_report_passes(tmp_path: Path) -> None:
         raise AssertionError("Expected audit exit code 0")
 
 
+def test_clean_report_non_vulnerability_failure_status_fails(tmp_path: Path) -> None:
+    """A clean report with non-vulnerability exit code must still fail."""
+    exit_code = _run(
+        tmp_path,
+        {
+            "auditReportVersion": 3,
+            "vulnerabilities": {},
+            "metadata": {"vulnerabilities": {"high": 0, "critical": 0}},
+        },
+        [],
+        exit_code=2,
+    )
+    if exit_code != 1:
+        raise AssertionError("Expected audit exit code 1")
+
+
 def test_unwaived_high_or_critical_report_fails(tmp_path: Path) -> None:
     """Unwaived high/critical issues should fail audit evaluation.
 

--- a/.circleci/scripts/test_frontend_dependency_audit_command.py
+++ b/.circleci/scripts/test_frontend_dependency_audit_command.py
@@ -33,7 +33,7 @@ def _extract_frontend_dependency_audit_command() -> list[str]:
     body_indent: int | None = None
     command_lines: list[str] = []
 
-    for raw_line in lines[command_line + 1:]:
+    for raw_line in lines[command_line + 1 :]:
         if raw_line.strip() == "":
             if body_indent is None:
                 continue
@@ -55,7 +55,9 @@ def _extract_frontend_dependency_audit_command() -> list[str]:
     return command_lines
 
 
-def _line_indices_in_order(command_lines: list[str], expected: list[str]) -> None:
+def _line_indices_in_order(
+    command_lines: list[str], expected: list[str]
+) -> None:
     """Assert each expected line appears in the command in order."""
     normalized = [line.strip() for line in command_lines if line.strip()]
     cursor = -1
@@ -66,11 +68,18 @@ def _line_indices_in_order(command_lines: list[str], expected: list[str]) -> Non
                 cursor = index
                 break
         else:
-            raise AssertionError(f"Expected command token not found in order: {token}")
+            raise AssertionError(
+                f"Expected command token not found in order: {token}"
+            )
 
 
 def test_frontend_audit_shell_command_sequence() -> None:
-    """Ensure audit command preserves exit-code capture under CircleCI errexit."""
+    """Ensure audit command preserves exit-code capture under CircleCI errexit.
+
+    Raises:
+        AssertionError: If the parsed command sequence is missing expected tokens
+            or the parser invocation does not propagate AUDIT_EXIT_CODE.
+    """
     command_lines = _extract_frontend_dependency_audit_command()
 
     _line_indices_in_order(
@@ -89,5 +98,9 @@ def test_frontend_audit_shell_command_sequence() -> None:
 
     normalized = [line.strip() for line in command_lines if line.strip()]
 
-    if not any("--exit-code \"$AUDIT_EXIT_CODE\"" in line for line in normalized):
-        raise AssertionError("Expected parser invocation to pass AUDIT_EXIT_CODE")
+    if not any(
+        '--exit-code "$AUDIT_EXIT_CODE"' in line for line in normalized
+    ):
+        raise AssertionError(
+            "Expected parser invocation to pass AUDIT_EXIT_CODE"
+        )

--- a/.circleci/scripts/test_frontend_dependency_audit_command.py
+++ b/.circleci/scripts/test_frontend_dependency_audit_command.py
@@ -1,0 +1,93 @@
+"""Tests for frontend dependency audit CircleCI command sequencing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _extract_frontend_dependency_audit_command() -> list[str]:
+    """Extract the CircleCI frontend audit shell block from config."""
+    config_path = Path(__file__).resolve().parent.parent / "config.yml"
+    lines = config_path.read_text(encoding="utf-8").splitlines()
+
+    step_start = None
+    for index, line in enumerate(lines):
+        if "name: Run Frontend Production Dependency Audit" in line:
+            step_start = index
+            break
+    if step_start is None:
+        raise AssertionError(
+            "Frontend dependency audit step not found in CircleCI config"
+        )
+
+    command_line = None
+    for index in range(step_start, len(lines)):
+        if lines[index].strip() == "command: |":
+            command_line = index
+            break
+    if command_line is None:
+        raise AssertionError(
+            "Frontend audit command block not found in CircleCI config"
+        )
+
+    body_indent: int | None = None
+    command_lines: list[str] = []
+
+    for raw_line in lines[command_line + 1:]:
+        if raw_line.strip() == "":
+            if body_indent is None:
+                continue
+            command_lines.append("")
+            continue
+
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if body_indent is None:
+            body_indent = indent
+
+        if indent < body_indent:
+            break
+
+        command_lines.append(raw_line[body_indent:])
+
+    if not command_lines:
+        raise AssertionError("Unable to parse frontend audit shell command")
+
+    return command_lines
+
+
+def _line_indices_in_order(command_lines: list[str], expected: list[str]) -> None:
+    """Assert each expected line appears in the command in order."""
+    normalized = [line.strip() for line in command_lines if line.strip()]
+    cursor = -1
+
+    for token in expected:
+        for index in range(cursor + 1, len(normalized)):
+            if normalized[index] == token:
+                cursor = index
+                break
+        else:
+            raise AssertionError(f"Expected command token not found in order: {token}")
+
+
+def test_frontend_audit_shell_command_sequence() -> None:
+    """Ensure audit command preserves exit-code capture under CircleCI errexit."""
+    command_lines = _extract_frontend_dependency_audit_command()
+
+    _line_indices_in_order(
+        command_lines,
+        [
+            "set +e",
+            (
+                "npm audit --omit=dev --audit-level=high "
+                "--json > /tmp/npm-audit-report.json"
+            ),
+            "AUDIT_EXIT_CODE=$?",
+            "set -e",
+            "python3 ../.circleci/scripts/check_frontend_dependency_audit.py \\",
+        ],
+    )
+
+    normalized = [line.strip() for line in command_lines if line.strip()]
+
+    if not any("--exit-code \"$AUDIT_EXIT_CODE\"" in line for line in normalized):
+        raise AssertionError("Expected parser invocation to pass AUDIT_EXIT_CODE")

--- a/.circleci/scripts/test_frontend_dependency_audit_command.py
+++ b/.circleci/scripts/test_frontend_dependency_audit_command.py
@@ -33,7 +33,8 @@ def _extract_frontend_dependency_audit_command() -> list[str]:
     body_indent: int | None = None
     command_lines: list[str] = []
 
-    for raw_line in lines[command_line + 1 :]:
+    audit_block_start = command_line + 1
+    for raw_line in lines[audit_block_start:]:
         if raw_line.strip() == "":
             if body_indent is None:
                 continue

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -332,16 +332,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.15"
+version = "5.2.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/e3/31722f7284c9f43333daff9aee9184678e4487adcb5506af0db8cea09ce1/django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7", size = 10873669, upload-time = "2026-06-03T13:03:35.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/b5/38140b1643c00d5c46ce69c78e6980fd285aee223100319631bedee4f5e7/django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970", size = 8311957, upload-time = "2026-06-03T13:03:31.329Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
 ]
 
 [[package]]
@@ -673,11 +673,11 @@ resolution-markers = [
     "python_full_version >= '3.14'",
 ]
 dependencies = [
-    { name = "google-auth", marker = "python_full_version >= '3.14'" },
-    { name = "googleapis-common-protos", marker = "python_full_version >= '3.14'" },
-    { name = "proto-plus", marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", marker = "python_full_version >= '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.14'" },
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/cd/63f1557235c2440fe0577acdbc32577c5c002684c58c7f4d770a92366a24/google_api_core-2.25.2.tar.gz", hash = "sha256:1c63aa6af0d0d5e37966f157a77f9396d820fba59f9e43e9415bc3dc5baff300", size = 166266, upload-time = "2025-10-03T00:07:34.778Z" }
 wheels = [
@@ -692,11 +692,11 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 dependencies = [
-    { name = "google-auth", marker = "python_full_version < '3.14'" },
-    { name = "googleapis-common-protos", marker = "python_full_version < '3.14'" },
-    { name = "proto-plus", marker = "python_full_version < '3.14'" },
-    { name = "protobuf", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/da/83d7043169ac2c8c7469f0e375610d78ae2160134bf1b80634c482fa079c/google_api_core-2.28.1.tar.gz", hash = "sha256:2b405df02d68e68ce0fbc138559e6036559e685159d148ae5861013dc201baf8", size = 176759, upload-time = "2025-10-28T21:34:51.529Z" }
 wheels = [
@@ -744,12 +744,12 @@ resolution-markers = [
     "python_full_version >= '3.14'",
 ]
 dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", marker = "python_full_version >= '3.14'" },
-    { name = "google-cloud-core", marker = "python_full_version >= '3.14'" },
-    { name = "google-crc32c", marker = "python_full_version >= '3.14'" },
-    { name = "google-resumable-media", marker = "python_full_version >= '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/ef/7cefdca67a6c8b3af0ec38612f9e78e5a9f6179dd91352772ae1a9849246/google_cloud_storage-3.4.1.tar.gz", hash = "sha256:6f041a297e23a4b485fad8c305a7a6e6831855c208bcbe74d00332a909f82268", size = 17238203, upload-time = "2025-10-08T18:43:39.665Z" }
 wheels = [
@@ -764,12 +764,12 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 dependencies = [
-    { name = "google-api-core", version = "2.28.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", marker = "python_full_version < '3.14'" },
-    { name = "google-cloud-core", marker = "python_full_version < '3.14'" },
-    { name = "google-crc32c", marker = "python_full_version < '3.14'" },
-    { name = "google-resumable-media", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "google-api-core", version = "2.28.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/8e/fab2de1a0ab7fdbd452eaae5a9a5c933d0911c26b04efa0c76ddfd921259/google_cloud_storage-3.7.0.tar.gz", hash = "sha256:9ce59c65f4d6e372effcecc0456680a8d73cef4f2dc9212a0704799cb3d69237", size = 17258914, upload-time = "2025-12-09T18:24:48.97Z" }
 wheels = [
@@ -2088,7 +2088,7 @@ wheels = [
 
 [[package]]
 name = "strawberry-django-auth"
-version = "0.378.4"
+version = "0.379.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -2096,9 +2096,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "strawberry-graphql-django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/27/79bb9c0c00db1b5ead8460c017b7cda1af2a8a516ea1e6a9b40095a66ef9/strawberry_django_auth-0.378.4.tar.gz", hash = "sha256:40bf6041507118b213d67e763f813219285be3c0f677aa4b869eb7df962a0f2c", size = 6932750, upload-time = "2025-02-17T12:10:18.01Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/3c/4a5c8ae4682b749e1f23fbfffe343c0d581b99c3ef3a7660021c88435d7c/strawberry_django_auth-0.379.1.tar.gz", hash = "sha256:7f4f00bb041ab4d77312a870a5f6a65ddde541ceb164865310564f14d39abc49", size = 6884470, upload-time = "2026-03-01T12:23:09.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/4c/ec0026f42e3b91cf46b2fa1cc7f3e8ae98887251a70bbc00621e0d182baa/strawberry_django_auth-0.378.4-py3-none-any.whl", hash = "sha256:dd0ea04312ef969aafdcbc2d6f4be9af883ae38d0e717d32ca1983a9c91887ac", size = 477461, upload-time = "2025-02-17T12:10:12.519Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c1/3ff537fd9d60b9f70a9915105460c762c2dc5283abd51542eeadc69a3add/strawberry_django_auth-0.379.1-py3-none-any.whl", hash = "sha256:beba63405c700aab16279f081c19b097dfd5cbe71bcd716a8bfaa9c39ceb2146", size = 477546, upload-time = "2026-03-01T12:23:10.697Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Upgraded runtime dependencies to address advisories from issue #375: Django is locked to `5.2.16` in `backend/uv.lock`, and production frontend dependency advisories were addressed by bumping `postcss` and `sharp` in `webapp/package.json` and refreshing `webapp/package-lock.json`.
- Added production dependency audit gates in CircleCI: `backend-dependency-audit` and `webapp-dependency-audit`.
- Added temporary waiver support files: `.circleci/dependency-audit-pip-allowlist.txt` and `.circleci/dependency-audit-npm-allowlist.txt`.
- Wired both audit jobs into the validation workflow before Docker build/deploy jobs.

## Evidence (exact commands and outcomes)
- `cd backend && uv export --format requirements-txt --no-hashes --no-dev > /tmp/backend-production-requirements.txt && uvx --from pip-audit pip-audit -r /tmp/backend-production-requirements.txt --no-deps --disable-pip`
  - Result: `No known vulnerabilities found`.
- `cd webapp && npm ci --ignore-scripts --silent && npm audit --omit=dev --audit-level=high`
  - Result: `found 0 vulnerabilities`.
- `cd webapp && npm test`
  - Result: `1..54`, `pass 54`, `fail 0`.
- `cd webapp && npx tsc --noEmit --ignoreDeprecations 6.0`
  - Result: exit code 0.
- `cd webapp && npm run build`
  - Result: production build completed successfully.
- `cd backend && SECRET_KEY=TestingSecretKeyThatIsAtLeast32BytesLong GEMINI_API_KEY=TestingApiKey uv run pytest -n 4 tests ../.circleci/scripts`
  - Result: failed in local environment due missing PostgreSQL on `localhost:5432` (connection refused), which is an environment prerequisite for backend test execution.

## Temporary waiver process
- Add temporary IDs to the allowlist files in `.circleci/` with explicit owner/date context and remove once patched upstream.

Closes #375
