### PR TITLE
Harden backend container runtime defaults and chart port contract

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,7 +262,9 @@ jobs:
           name: Build, Tag and Push Backend
           command: |
              apk add --no-cache make
-             TAG=$CIRCLE_SHA1 make docker-build-tag-push
+             TAG=$CIRCLE_SHA1 make docker-build
+             IMAGE_NAME=luismunozvillarreal/nutrition-backend IMAGE_TAG=$CIRCLE_SHA1 SKIP_IMAGE_BUILD=1 make docker-contract-test
+             TAG=$CIRCLE_SHA1 make docker-push
 
   webapp-docker-build-tag-push:
     working_directory: ~/project/webapp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,9 +262,7 @@ jobs:
           name: Build, Tag and Push Backend
           command: |
              apk add --no-cache make
-             TAG=$CIRCLE_SHA1 make docker-build
-             IMAGE_NAME=luismunozvillarreal/nutrition-backend IMAGE_TAG=$CIRCLE_SHA1 SKIP_IMAGE_BUILD=1 PRESERVE_IMAGE=1 make docker-contract-test
-             TAG=$CIRCLE_SHA1 make docker-push
+             IMAGE_NAME=luismunozvillarreal/nutrition-backend TAG=$CIRCLE_SHA1 make docker-build-contract-tag-push
 
   webapp-docker-build-tag-push:
     working_directory: ~/project/webapp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
           command: |
              apk add --no-cache make
              TAG=$CIRCLE_SHA1 make docker-build
-             IMAGE_NAME=luismunozvillarreal/nutrition-backend IMAGE_TAG=$CIRCLE_SHA1 SKIP_IMAGE_BUILD=1 make docker-contract-test
+             IMAGE_NAME=luismunozvillarreal/nutrition-backend IMAGE_TAG=$CIRCLE_SHA1 SKIP_IMAGE_BUILD=1 PRESERVE_IMAGE=1 make docker-contract-test
              TAG=$CIRCLE_SHA1 make docker-push
 
   webapp-docker-build-tag-push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,6 +281,17 @@ jobs:
              apk add --no-cache make
              TAG=$CIRCLE_SHA1 make docker-build-tag-push
 
+  chart-contract-tests:
+    working_directory: ~/project
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run:
+          name: Run Helm chart contract tests
+          working_directory: ~/project/backend
+          command: make chart-contract-test
+
   deploy-preview:
     working_directory: ~/project
     docker:
@@ -474,6 +485,7 @@ workflows:
       - backend-dependency-audit
       - webapp-dependency-audit
       - webapp-checks
+      - chart-contract-tests
       - backend-docker-build-tag-push:
           context:
             - Docker
@@ -498,6 +510,7 @@ workflows:
           context:
             - kubeconfig
           requires:
+            - chart-contract-tests
             - backend-docker-build-tag-push
             - webapp-docker-build-tag-push
           filters:
@@ -508,6 +521,7 @@ workflows:
           context:
             - kubeconfig
           requires:
+            - chart-contract-tests
             - backend-docker-build-tag-push
             - webapp-docker-build-tag-push
           filters:
@@ -518,6 +532,7 @@ workflows:
           context:
             - kubeconfig
           requires:
+            - chart-contract-tests
             - backend-docker-build-tag-push
             - webapp-docker-build-tag-push
           filters:

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -5,7 +5,7 @@ SECRET_KEY?=insecure-local-test-secret
 GEMINI_API_KEY?=local-test-gemini-key
 DATABASE_URL?=sqlite:///db.sqlite3
 
-.PHONY: install python-checks pytest bandit flake8 black mypy pylint pylint-tests pydocstyle pydocstyle-tests docker-build docker-tag docker-push restore-db migrations-check migrate ci-migrations chart-contract-test docker-contract-test contract-tests
+.PHONY: install python-checks pytest bandit flake8 black mypy pylint pylint-tests pydocstyle pydocstyle-tests docker-build docker-tag docker-push docker-build-contract-tag-push restore-db migrations-check migrate ci-migrations chart-contract-test docker-contract-test contract-tests
 
 install:
 	uv sync
@@ -57,6 +57,11 @@ docker-push:
 	docker push $(IMAGE_NAME):latest
 
 docker-build-tag-push: docker-build docker-tag docker-push
+
+docker-build-contract-tag-push:
+	IMAGE_NAME=$(IMAGE_NAME) TAG=$(TAG) IMAGE_TAG=$(TAG) $(MAKE) docker-build
+	IMAGE_NAME=$(IMAGE_NAME) IMAGE_TAG=$(TAG) SKIP_IMAGE_BUILD=1 PRESERVE_IMAGE=1 $(MAKE) docker-contract-test
+	IMAGE_NAME=$(IMAGE_NAME) TAG=$(TAG) $(MAKE) docker-tag docker-push
 
 chart-contract-test:
 	./platform/kube/tests/chart-contract-test.sh

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -5,7 +5,7 @@ SECRET_KEY?=insecure-local-test-secret
 GEMINI_API_KEY?=local-test-gemini-key
 DATABASE_URL?=sqlite:///db.sqlite3
 
-.PHONY: install python-checks pytest bandit flake8 black mypy pylint pylint-tests pydocstyle pydocstyle-tests docker-build docker-tag docker-push restore-db migrations-check migrate ci-migrations
+.PHONY: install python-checks pytest bandit flake8 black mypy pylint pylint-tests pydocstyle pydocstyle-tests docker-build docker-tag docker-push restore-db migrations-check migrate ci-migrations chart-contract-test docker-contract-test contract-tests
 
 install:
 	uv sync
@@ -57,6 +57,14 @@ docker-push:
 	docker push $(IMAGE_NAME):latest
 
 docker-build-tag-push: docker-build docker-tag docker-push
+
+chart-contract-test:
+	./platform/kube/tests/chart-contract-test.sh
+
+docker-contract-test:
+	./platform/docker/tests/docker-contract-test.sh
+
+contract-tests: chart-contract-test docker-contract-test
 
 restore-db:
 	uv run ./manage.py dbrestore --noinput -d nutrition

--- a/backend/apps/foods/nutrition_facts_finder.py
+++ b/backend/apps/foods/nutrition_facts_finder.py
@@ -229,14 +229,15 @@ def _response_bytes(
     content_length = response.headers.get("Content-Length")
     if content_length is not None:
         try:
-            if int(content_length) > max_size:
-                raise NutritionFactsFetchError(
-                    f"Response exceeds max size: {content_length}"
-                )
+            parsed_length = int(content_length)
         except ValueError as exc:
             raise NutritionFactsFetchError(
                 "Invalid Content-Length header"
             ) from exc
+        if parsed_length > max_size:
+            raise NutritionFactsFetchError(
+                f"Response exceeds max size: {content_length}"
+            )
 
     collected: bytearray = bytearray()
     for chunk in response.iter_content(STREAM_CHUNK_SIZE):

--- a/backend/platform/docker/Dockerfile
+++ b/backend/platform/docker/Dockerfile
@@ -19,8 +19,6 @@ RUN \
   postgresql-client \
   # Locales
   locales \
-  # Sudo
-  sudo \
   # Server
   nginx \
   libnginx-mod-http-lua \
@@ -52,10 +50,6 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # Add user and group
 ENV USER_NAME=$NAME
 RUN useradd -u 1001 -ms /bin/bash $USER_NAME
-
-# Add user to sudo group
-RUN echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-RUN /etc/init.d/sudo restart
 
 # Server directory
 ENV SRC_DIR="/srv/www/$NAME"
@@ -93,8 +87,8 @@ USER $USER_NAME
 RUN mkdir static
 RUN mkdir -p public/static
 
-# Open server port
-EXPOSE 80
+# Public listener on 8080 and health listener on 9000
+EXPOSE 8080 9000
 
 # Entry point
 COPY platform/docker/entrypoint.sh \

--- a/backend/platform/docker/tests/docker-contract-test.sh
+++ b/backend/platform/docker/tests/docker-contract-test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+IMAGE_NAME="${IMAGE_NAME:-nutrition-backend-contract-test}"
+IMAGE_TAG="${IMAGE_TAG:-ci}"
+IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
+DOCKERFILE_PATH="${SCRIPT_DIR}/../Dockerfile"
+
+docker build -f "$DOCKERFILE_PATH" -t "$IMAGE" "$PROJECT_ROOT"
+
+trap 'docker image rm -f "$IMAGE" >/dev/null 2>&1 || true' EXIT
+
+if grep -q "NOPASSWD:ALL" "$DOCKERFILE_PATH"; then
+  echo "Dockerfile still defines passwordless sudo" >&2
+  exit 1
+fi
+
+if ! grep -E "^EXPOSE[[:space:]]+8080[[:space:]]+9000" "$DOCKERFILE_PATH" >/dev/null 2>&1; then
+  echo "Dockerfile does not expose required backend listeners 8080 and 9000" >&2
+  exit 1
+fi
+
+if grep -Eq "\\bsudo\\b" "$DOCKERFILE_PATH"; then
+  echo "Dockerfile still installs or references sudo" >&2
+  exit 1
+fi
+
+RUNTIME_CHECK="$(
+  docker run --rm --entrypoint /bin/bash "$IMAGE" -lc '
+    set -euo pipefail
+
+    if [ "$(id -u)" -eq 0 ]; then
+      echo "runtime user is root" >&2
+      exit 1
+    fi
+
+    if grep -Rqs "NOPASSWD:ALL" /etc/sudoers /etc/sudoers.d 2>/dev/null; then
+      echo "runtime image contains NOPASSWD sudo policy" >&2
+      exit 1
+    fi
+
+    if command -v sudo >/dev/null 2>&1; then
+      if sudo -n true >/dev/null 2>&1; then
+        echo "runtime image can escalate privileges without password" >&2
+        exit 1
+      fi
+    fi
+
+    echo "runtime_uid=$(id -u)"
+  '
+)"
+
+if ! echo "$RUNTIME_CHECK" | grep -q "runtime_uid="; then
+  echo "Runtime container contract check failed" >&2
+  exit 1
+fi
+
+echo "$RUNTIME_CHECK"
+echo "Backend image contract tests passed."

--- a/backend/platform/docker/tests/docker-contract-test.sh
+++ b/backend/platform/docker/tests/docker-contract-test.sh
@@ -40,8 +40,8 @@ if grep -Eq "\\bsudo\\b" "$DOCKERFILE_PATH"; then
 fi
 
 RUNTIME_CHECK="$(
-  docker run --rm --entrypoint /bin/bash "$IMAGE" -lc '
-    set -euo pipefail
+  docker run --rm --entrypoint /bin/sh "$IMAGE" -lc '
+    set -eu
 
     if [ "$(id -u)" -eq 0 ]; then
       echo "runtime user is root" >&2

--- a/backend/platform/docker/tests/docker-contract-test.sh
+++ b/backend/platform/docker/tests/docker-contract-test.sh
@@ -8,8 +8,16 @@ IMAGE_NAME="${IMAGE_NAME:-nutrition-backend-contract-test}"
 IMAGE_TAG="${IMAGE_TAG:-ci}"
 IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
 DOCKERFILE_PATH="${SCRIPT_DIR}/../Dockerfile"
+SKIP_IMAGE_BUILD="${SKIP_IMAGE_BUILD:-0}"
 
-docker build -f "$DOCKERFILE_PATH" -t "$IMAGE" "$PROJECT_ROOT"
+if [ "$SKIP_IMAGE_BUILD" = "1" ]; then
+  if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "Contract image ${IMAGE} is not available and SKIP_IMAGE_BUILD is enabled." >&2
+    exit 1
+  fi
+else
+  docker build -f "$DOCKERFILE_PATH" -t "$IMAGE" "$PROJECT_ROOT"
+fi
 
 trap 'docker image rm -f "$IMAGE" >/dev/null 2>&1 || true' EXIT
 

--- a/backend/platform/docker/tests/docker-contract-test.sh
+++ b/backend/platform/docker/tests/docker-contract-test.sh
@@ -9,6 +9,7 @@ IMAGE_TAG="${IMAGE_TAG:-ci}"
 IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
 DOCKERFILE_PATH="${SCRIPT_DIR}/../Dockerfile"
 SKIP_IMAGE_BUILD="${SKIP_IMAGE_BUILD:-0}"
+PRESERVE_IMAGE="${PRESERVE_IMAGE:-0}"
 
 if [ "$SKIP_IMAGE_BUILD" = "1" ]; then
   if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
@@ -19,7 +20,9 @@ else
   docker build -f "$DOCKERFILE_PATH" -t "$IMAGE" "$PROJECT_ROOT"
 fi
 
-trap 'docker image rm -f "$IMAGE" >/dev/null 2>&1 || true' EXIT
+if [ "$PRESERVE_IMAGE" != "1" ]; then
+  trap 'docker image rm -f "$IMAGE" >/dev/null 2>&1 || true' EXIT
+fi
 
 if grep -q "NOPASSWD:ALL" "$DOCKERFILE_PATH"; then
   echo "Dockerfile still defines passwordless sudo" >&2

--- a/backend/platform/docker/tests/docker-contract-test.sh
+++ b/backend/platform/docker/tests/docker-contract-test.sh
@@ -1,8 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-set -euo pipefail
+set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 IMAGE_NAME="${IMAGE_NAME:-nutrition-backend-contract-test}"
 IMAGE_TAG="${IMAGE_TAG:-ci}"

--- a/backend/platform/kube/templates/cronjob-dbbackup.yaml
+++ b/backend/platform/kube/templates/cronjob-dbbackup.yaml
@@ -9,6 +9,8 @@ spec:
       template:
         spec:
           serviceAccountName: {{ include "nutrition.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
           volumes:
             - name: nutrition-gcp-db-backup-credentials
               secret:
@@ -17,6 +19,8 @@ spec:
           - name: {{ .Chart.Name }}-dbbackup
             image: {{ .Values.image.repository }}:{{ include "nutrition.imageTag" . }}
             imagePullPolicy: IfNotPresent
+            securityContext:
+              {{- toYaml .Values.securityContext | nindent 14 }}
             {{- with .Values.env }}
             env:
               {{- toYaml . | nindent 12 }}

--- a/backend/platform/kube/templates/cronjob-dbbackup.yaml
+++ b/backend/platform/kube/templates/cronjob-dbbackup.yaml
@@ -35,7 +35,7 @@ spec:
                   command:
                     - /bin/sh
                     - -c
-                    - ln -s /mnt/secret/nutrition-gcp-db-backup-credentials.json /srv/www/backend/nutrition-gcp-db-backup-credentials.json
+                    - ln -sf /mnt/secret/nutrition-gcp-db-backup-credentials.json /srv/www/backend/nutrition-gcp-db-backup-credentials.json
             command:
               - /bin/bash
               - -c

--- a/backend/platform/kube/templates/deployment.yaml
+++ b/backend/platform/kube/templates/deployment.yaml
@@ -38,22 +38,25 @@ spec:
           image: {{ .Values.image.repository }}:{{ include "nutrition.imageTag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http
-              containerPort: 80
+            - name: public
+              containerPort: {{ .Values.containerPorts.public }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ .Values.containerPorts.health }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz/
-              port: 9000
+              port: health
             initialDelaySeconds: 15
           readinessProbe:
             httpGet:
               path: /healthz/
-              port: 9000
+              port: health
           startupProbe:
             httpGet:
               path: /healthz/
-              port: 9000
+              port: health
             initialDelaySeconds: 15
             failureThreshold: 600
             periodSeconds: 5

--- a/backend/platform/kube/templates/deployment.yaml
+++ b/backend/platform/kube/templates/deployment.yaml
@@ -37,12 +37,13 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ .Values.image.repository }}:{{ include "nutrition.imageTag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- $containerPorts := .Values.containerPorts | default dict }}
           ports:
             - name: public
-              containerPort: {{ .Values.containerPorts.public }}
+              containerPort: {{ default 8080 $containerPorts.public }}
               protocol: TCP
             - name: health
-              containerPort: {{ .Values.containerPorts.health }}
+              containerPort: {{ default 9000 $containerPorts.health }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/backend/platform/kube/templates/deployment.yaml
+++ b/backend/platform/kube/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
                 command:
                   - /bin/sh
                   - -c
-                  - ln -s /mnt/secret/nutrition-gcp-db-backup-credentials.json /srv/www/backend/nutrition-gcp-db-backup-credentials.json
+                  - ln -sf /mnt/secret/nutrition-gcp-db-backup-credentials.json /srv/www/backend/nutrition-gcp-db-backup-credentials.json
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/backend/platform/kube/templates/service.yaml
+++ b/backend/platform/kube/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
   selector:

--- a/backend/platform/kube/templates/service.yaml
+++ b/backend/platform/kube/templates/service.yaml
@@ -6,9 +6,10 @@ metadata:
     {{- include "nutrition.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- $service := .Values.service | default dict }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
+      targetPort: {{ default "public" $service.targetPort }}
       protocol: TCP
       name: http
   selector:

--- a/backend/platform/kube/tests/chart-contract-test.sh
+++ b/backend/platform/kube/tests/chart-contract-test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HELM_CACHE_DIR="${SCRIPT_DIR}/.cache/helm"
+HELM_BIN="${HELM_BIN:-${HELM_CACHE_DIR}/helm}"
+HELM_VERSION="${HELM_VERSION:-v3.16.2}"
+RENDER_DIR="$(mktemp -d)"
+
+if [[ ! -x "$HELM_BIN" ]]; then
+  if command -v helm >/dev/null 2>&1; then
+    HELM_BIN="$(command -v helm)"
+  else
+    mkdir -p "$HELM_CACHE_DIR"
+    if [[ -f "${HELM_CACHE_DIR}/helm" && ! -x "${HELM_CACHE_DIR}/helm" ]]; then
+      rm -f "${HELM_CACHE_DIR}/helm"
+    fi
+
+    HELM_ARCH="$(uname -m)"
+    case "${HELM_ARCH}" in
+      x86_64) HELM_ARCH="amd64" ;;
+      aarch64|arm64) HELM_ARCH="arm64" ;;
+      *) echo "Unsupported architecture: ${HELM_ARCH}" >&2; exit 1 ;;
+    esac
+
+    echo "Helm not found, downloading ${HELM_VERSION} for linux/${HELM_ARCH} to ${HELM_BIN}..."
+    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${HELM_ARCH}.tar.gz" \
+      | tar -xz -C "$HELM_CACHE_DIR" --strip-components=1 "linux-${HELM_ARCH}/helm"
+  fi
+fi
+
+trap 'rm -rf "$RENDER_DIR"' EXIT
+
+echo "Ensuring chart dependencies are present..."
+"$HELM_BIN" dependency build "$CHART_DIR"
+
+echo "Using helm binary: $HELM_BIN"
+echo "Running helm lint..."
+"$HELM_BIN" lint "$CHART_DIR"
+"$HELM_BIN" template nutrition-backend "$CHART_DIR" --validate > /dev/null
+
+FULL_RENDER="$RENDER_DIR/rendered-chart.yaml"
+"$HELM_BIN" template nutrition-backend "$CHART_DIR" > "$FULL_RENDER"
+
+if command -v kubectl >/dev/null 2>&1; then
+  echo "Running manifest validation..."
+  kubectl apply --dry-run=client --validate=true -f "$FULL_RENDER"
+else
+  echo "kubectl not found; skipping kubectl dry-run validation."
+fi
+
+DEPLOYMENT_MANIFEST_PATH="$RENDER_DIR/deployment.yaml"
+SERVICE_MANIFEST_PATH="$RENDER_DIR/service.yaml"
+
+"$HELM_BIN" template nutrition-backend "$CHART_DIR" --show-only templates/deployment.yaml > "$DEPLOYMENT_MANIFEST_PATH"
+"$HELM_BIN" template nutrition-backend "$CHART_DIR" --show-only templates/service.yaml > "$SERVICE_MANIFEST_PATH"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if ! printf '%s\n' "$haystack" | grep -Fq -- "$needle"; then
+    echo "Contract test failed: expected ${label}: ${needle}" >&2
+    exit 1
+  fi
+}
+
+assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "name: public" "named public listener port"
+assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "containerPort: 8080" "public listener port 8080"
+assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "name: health" "named health listener port"
+assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "containerPort: 9000" "health listener port 9000"
+assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "port: health" "liveness/readiness/startup on health port"
+assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "runAsNonRoot: true" "non-root runtime enforcement"
+assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "allowPrivilegeEscalation: false" "no privilege escalation"
+assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "noNewPrivileges: true" "no-new-privileges enforcement"
+assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "- ALL" "restricted capabilities in deployment"
+assert_contains "$(< "$SERVICE_MANIFEST_PATH")" "targetPort: public" "service target to public listener"
+assert_contains "$(< "$FULL_RENDER")" "containerPort: 8080" "rendered chart exposes public listener port"
+
+echo "Chart contract tests passed."

--- a/backend/platform/kube/tests/chart-contract-test.sh
+++ b/backend/platform/kube/tests/chart-contract-test.sh
@@ -5,8 +5,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 HELM_CACHE_DIR="${SCRIPT_DIR}/.cache/helm"
+KUBECONFORM_CACHE_DIR="${SCRIPT_DIR}/.cache/kubeconform"
 HELM_BIN="${HELM_BIN:-${HELM_CACHE_DIR}/helm}"
+KUBECONFORM_BIN="${KUBECONFORM_BIN:-${KUBECONFORM_CACHE_DIR}/kubeconform}"
 HELM_VERSION="${HELM_VERSION:-v3.16.2}"
+KUBECONFORM_VERSION="${KUBECONFORM_VERSION:-v0.8.0}"
+KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.33.0}"
 RENDER_DIR="$(mktemp -d)"
 
 if [[ ! -x "$HELM_BIN" ]]; then
@@ -31,6 +35,29 @@ if [[ ! -x "$HELM_BIN" ]]; then
   fi
 fi
 
+if [[ ! -x "$KUBECONFORM_BIN" ]]; then
+  if command -v kubeconform >/dev/null 2>&1; then
+    KUBECONFORM_BIN="$(command -v kubeconform)"
+  else
+    mkdir -p "$KUBECONFORM_CACHE_DIR"
+    if [[ -f "${KUBECONFORM_CACHE_DIR}/kubeconform" && ! -x "${KUBECONFORM_CACHE_DIR}/kubeconform" ]]; then
+      rm -f "${KUBECONFORM_CACHE_DIR}/kubeconform"
+    fi
+
+    KUBECONFORM_ARCH="$(uname -m)"
+    case "${KUBECONFORM_ARCH}" in
+      x86_64) KUBECONFORM_ARCH="amd64" ;;
+      aarch64|arm64) KUBECONFORM_ARCH="arm64" ;;
+      *) echo "Unsupported architecture: ${KUBECONFORM_ARCH}" >&2; exit 1 ;;
+    esac
+
+    echo "kubeconform not found, downloading ${KUBECONFORM_VERSION} for linux/${KUBECONFORM_ARCH} to ${KUBECONFORM_BIN}..."
+    curl -fsSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-${KUBECONFORM_ARCH}.tar.gz" \
+      | tar -xz -C "$KUBECONFORM_CACHE_DIR"
+  fi
+fi
+chmod +x "$KUBECONFORM_BIN"
+
 trap 'rm -rf "$RENDER_DIR"' EXIT
 
 echo "Ensuring chart dependencies are present..."
@@ -51,11 +78,27 @@ else
   echo "kubectl not found; skipping kubectl dry-run validation."
 fi
 
+echo "Running strict schema validation..."
+"$KUBECONFORM_BIN" -strict -summary -kubernetes-version "$KUBERNETES_VERSION" "$FULL_RENDER"
+
 DEPLOYMENT_MANIFEST_PATH="$RENDER_DIR/deployment.yaml"
 SERVICE_MANIFEST_PATH="$RENDER_DIR/service.yaml"
+CRONJOB_MANIFEST_PATH="$RENDER_DIR/cronjob-dbbackup.yaml"
+LEGACY_VALUES_PATH="$RENDER_DIR/legacy-values.yaml"
+LEGACY_DEPLOYMENT_MANIFEST_PATH="$RENDER_DIR/legacy-deployment.yaml"
+LEGACY_SERVICE_MANIFEST_PATH="$RENDER_DIR/legacy-service.yaml"
 
 "$HELM_BIN" template nutrition-backend "$CHART_DIR" --show-only templates/deployment.yaml > "$DEPLOYMENT_MANIFEST_PATH"
 "$HELM_BIN" template nutrition-backend "$CHART_DIR" --show-only templates/service.yaml > "$SERVICE_MANIFEST_PATH"
+"$HELM_BIN" template nutrition-backend "$CHART_DIR" --show-only templates/cronjob-dbbackup.yaml > "$CRONJOB_MANIFEST_PATH"
+
+cat <<'EOF' > "$LEGACY_VALUES_PATH"
+service:
+  port: 80
+EOF
+
+"$HELM_BIN" template nutrition-backend "$CHART_DIR" -f "$LEGACY_VALUES_PATH" --show-only templates/deployment.yaml > "$LEGACY_DEPLOYMENT_MANIFEST_PATH"
+"$HELM_BIN" template nutrition-backend "$CHART_DIR" -f "$LEGACY_VALUES_PATH" --show-only templates/service.yaml > "$LEGACY_SERVICE_MANIFEST_PATH"
 
 assert_contains() {
   local haystack="$1"
@@ -67,6 +110,16 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if printf '%s\n' "$haystack" | grep -Fq -- "$needle"; then
+    echo "Contract test failed: unexpected ${label}: ${needle}" >&2
+    exit 1
+  fi
+}
+
 assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "name: public" "named public listener port"
 assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "containerPort: 8080" "public listener port 8080"
 assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "name: health" "named health listener port"
@@ -74,9 +127,17 @@ assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "containerPort: 9000" "health
 assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "port: health" "liveness/readiness/startup on health port"
 assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "runAsNonRoot: true" "non-root runtime enforcement"
 assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "allowPrivilegeEscalation: false" "no privilege escalation"
-assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "noNewPrivileges: true" "no-new-privileges enforcement"
 assert_contains "$(< "$DEPLOYMENT_MANIFEST_PATH")" "- ALL" "restricted capabilities in deployment"
 assert_contains "$(< "$SERVICE_MANIFEST_PATH")" "targetPort: public" "service target to public listener"
+assert_contains "$(< "$CRONJOB_MANIFEST_PATH")" "runAsNonRoot: true" "cronjob pod runs as non-root"
+assert_contains "$(< "$CRONJOB_MANIFEST_PATH")" "allowPrivilegeEscalation: false" "cronjob container does not allow privilege escalation"
+assert_contains "$(< "$CRONJOB_MANIFEST_PATH")" "- ALL" "cronjob container drops all capabilities"
 assert_contains "$(< "$FULL_RENDER")" "containerPort: 8080" "rendered chart exposes public listener port"
+assert_contains "$(< "$LEGACY_DEPLOYMENT_MANIFEST_PATH")" "name: public" "legacy values preserve public listener name"
+assert_contains "$(< "$LEGACY_DEPLOYMENT_MANIFEST_PATH")" "containerPort: 8080" "legacy values default public listener port"
+assert_contains "$(< "$LEGACY_DEPLOYMENT_MANIFEST_PATH")" "name: health" "legacy values preserve health listener name"
+assert_contains "$(< "$LEGACY_DEPLOYMENT_MANIFEST_PATH")" "containerPort: 9000" "legacy values default health listener port"
+assert_contains "$(< "$LEGACY_SERVICE_MANIFEST_PATH")" "targetPort: public" "legacy values default service target to public listener"
+assert_not_contains "$(< "$FULL_RENDER")" "noNewPrivileges" "unsupported noNewPrivileges field"
 
 echo "Chart contract tests passed."

--- a/backend/platform/kube/tests/chart-contract-test.sh
+++ b/backend/platform/kube/tests/chart-contract-test.sh
@@ -66,7 +66,6 @@ echo "Ensuring chart dependencies are present..."
 echo "Using helm binary: $HELM_BIN"
 echo "Running helm lint..."
 "$HELM_BIN" lint "$CHART_DIR"
-"$HELM_BIN" template nutrition-backend "$CHART_DIR" --validate > /dev/null
 
 FULL_RENDER="$RENDER_DIR/rendered-chart.yaml"
 "$HELM_BIN" template nutrition-backend "$CHART_DIR" > "$FULL_RENDER"

--- a/backend/platform/kube/values.yaml
+++ b/backend/platform/kube/values.yaml
@@ -22,20 +22,35 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  # runAsUser: 1001
+  # runAsGroup: 1001
+  # fsGroup: 1001
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
 
-securityContext: {}
+securityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  noNewPrivileges: true
   # capabilities:
   #   drop:
   #   - ALL
+  capabilities:
+    drop:
+      - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 service:
   type: ClusterIP
   port: 80
+  targetPort: public
+
+containerPorts:
+  public: 8080
+  health: 9000
 
 ingress:
   enabled: true

--- a/backend/platform/kube/values.yaml
+++ b/backend/platform/kube/values.yaml
@@ -32,9 +32,7 @@ podSecurityContext:
   fsGroup: 1001
 
 securityContext:
-  runAsNonRoot: true
   allowPrivilegeEscalation: false
-  noNewPrivileges: true
   # capabilities:
   #   drop:
   #   - ALL

--- a/backend/tests/config/test_security.py
+++ b/backend/tests/config/test_security.py
@@ -1,8 +1,16 @@
 """Tests for Django production security settings."""
 
+import ipaddress
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 from django.core import checks
 from django.test import override_settings
+
+from config.middleware import TrustedForwardedProtoMiddleware
 
 
 @pytest.mark.django_db
@@ -185,3 +193,65 @@ def test_allowed_cidr_nets_trust_boundary_is_configurable(client):
     )
     assert response.status_code == 200
     assert "Strict-Transport-Security" in response.headers
+
+
+@pytest.mark.django_db
+@override_settings(ALLOWED_CIDR_NETS=["not-a-cidr", "10.0.0.0/8"])
+def test_middleware_skips_invalid_cidr_entries():
+    """Invalid CIDR strings are ignored instead of breaking startup."""
+    middleware = TrustedForwardedProtoMiddleware(lambda request: None)
+
+    assert middleware.allowed_nets == [ipaddress.ip_network("10.0.0.0/8")]
+
+
+@pytest.mark.django_db
+@override_settings(
+    SESSION_COOKIE_SECURE=True,
+    CSRF_COOKIE_SECURE=True,
+    SECURE_SSL_REDIRECT=True,
+    SECURE_HSTS_SECONDS=86400,
+    SECURE_HSTS_INCLUDE_SUBDOMAINS=True,
+    SECURE_HSTS_PRELOAD=True,
+)
+def test_middleware_strips_forwarded_proto_from_unparsable_peer(client):
+    """A non-IP peer address fails closed and the header is stripped."""
+    response = client.get(
+        "/admin/login/",
+        secure=False,
+        follow=False,
+        REMOTE_ADDR="not-an-ip",
+        HTTP_X_FORWARDED_PROTO="https",
+    )
+    assert response.status_code == 301
+    assert response["Location"].startswith("https://")
+
+
+def test_production_csrf_origins_derive_from_allowed_hosts():
+    """Production auto-derives CSRF origins when none are configured."""
+    coverage_config = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    env = {
+        **os.environ,
+        "DJANGO_SETTINGS_MODULE": "config.settings",
+        "ENVIRONMENT": "production",
+        "ALLOWED_HOSTS": "example.com",
+        "CSRF_TRUSTED_ORIGINS": "",
+        "SECRET_KEY": "local-security-regression-key-with-plenty-of-entropy",
+        "GEMINI_API_KEY": "local-test-key",
+        "DATABASE_URL": "sqlite:///tmp/nutrition-settings-check.sqlite3",
+        "COVERAGE_PROCESS_START": str(coverage_config),
+    }
+    probe = (
+        "import django; django.setup(); "
+        "from django.conf import settings; "
+        "assert 'https://example.com' in settings.CSRF_TRUSTED_ORIGINS, "
+        "settings.CSRF_TRUSTED_ORIGINS"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_ocado.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_ocado.py
@@ -99,6 +99,28 @@ def test_ocado_missing_url(gemini_api, ocado_request):
     assert "URL is required" in str(form.errors)
 
 
+def test_ocado_form_surfaces_scrape_errors_as_validation(monkeypatch):
+    """Transport failures surface as form validation errors."""
+
+    def _boom(url):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(
+        "apps.foods.admin.product.get_product_nutritional_info_from_url",
+        _boom,
+    )
+    data = {
+        "scrape_info_from_url": True,
+        "url": URL,
+        **DEFAULT_FORM_DATA,
+    }
+
+    form = FoodProductForm(data=data)
+
+    assert not form.is_valid()
+    assert "boom" in str(form.errors)
+
+
 @pytest.mark.parametrize(
     "gemini_api",
     (

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
@@ -668,7 +668,7 @@ def test_adapter_rejects_unvalidated_destination_host():
 
 
 def test_parse_host_rejects_url_without_hostname():
-    """URLs that cannot yield a hostname are rejected in the transport."""
+    """Reject URLs that cannot yield a hostname in the transport."""
     adapter = _build_scraper_session(
         {"good.example.com": "203.0.113.11"}
     ).get_adapter("https://good.example.com/")
@@ -718,7 +718,7 @@ def test_validate_host_rejects_empty_resolution(monkeypatch):
 
 
 def test_validate_url_rejects_missing_hostname():
-    """URLs without a hostname fail closed."""
+    """Reject URLs without a hostname."""
     with pytest.raises(ValueError, match="URL must include a valid host"):
         _validate_url("https://")
 

--- a/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
+++ b/backend/tests/foods/nutrition_facts_finder/test_scrape_security.py
@@ -1,5 +1,7 @@
 """Tests for nutrition URL scraper hardening."""
 
+# pylint: disable=protected-access
+
 import socket
 import time
 
@@ -14,10 +16,13 @@ from apps.foods.nutrition_facts_finder import (
     MAX_RESPONSE_BYTES,
     _build_scraper_session,
     _follow_redirects,
+    _request_timeout,
     _resolve_redirect_url,
     _response_bytes,
     _ScraperHTTPSAdapter,
+    _validate_host,
     _validate_url,
+    _validated_url,
     get_product_nutritional_info_from_url,
 )
 
@@ -649,3 +654,158 @@ def test_scrape_rejects_oversized_streamed_body():
 
     with pytest.raises(ValueError, match="Response exceeded"):
         _response_bytes(response, deadline=time.monotonic() + 5)
+
+
+def test_adapter_rejects_unvalidated_destination_host():
+    """A host not pinned in the session map is refused at send time."""
+    adapter = _build_scraper_session(
+        {"good.example.com": "203.0.113.11"}
+    ).get_adapter("https://good.example.com/")
+    request = requests.Request("GET", "https://evil.example.com/").prepare()
+
+    with pytest.raises(ValueError, match="was not validated"):
+        adapter.send(request)
+
+
+def test_parse_host_rejects_url_without_hostname():
+    """URLs that cannot yield a hostname are rejected in the transport."""
+    adapter = _build_scraper_session(
+        {"good.example.com": "203.0.113.11"}
+    ).get_adapter("https://good.example.com/")
+
+    with pytest.raises(ValueError, match="Invalid URL hostname"):
+        adapter._parse_host("https:///path")
+
+
+@pytest.mark.parametrize("url", [None, ""])
+def test_validated_url_rejects_empty_input(url):
+    """Empty transport URLs fail closed."""
+    with pytest.raises(
+        ValueError, match="Invalid URL provided to scraper transport"
+    ):
+        _validated_url(url)
+
+
+def test_validate_host_accepts_public_ip_literal():
+    """Public IP literals are returned without DNS resolution."""
+    assert _validate_host("93.184.216.34") == "93.184.216.34"
+
+
+def test_validate_host_reports_unresolvable_hostname(monkeypatch):
+    """DNS failures surface as fetch errors, not raw socket errors."""
+
+    def _unresolvable(*args, **kwargs):
+        raise socket.gaierror("name or service not known")
+
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _unresolvable,
+    )
+
+    with pytest.raises(ValueError, match="Unresolvable host"):
+        _validate_host("unresolvable.example.com")
+
+
+def test_validate_host_rejects_empty_resolution(monkeypatch):
+    """A host that resolves to no addresses is rejected."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        lambda *args, **kwargs: [],
+    )
+
+    with pytest.raises(ValueError, match="No addresses resolved"):
+        _validate_host("no-records.example.com")
+
+
+def test_validate_url_rejects_missing_hostname():
+    """URLs without a hostname fail closed."""
+    with pytest.raises(ValueError, match="URL must include a valid host"):
+        _validate_url("https://")
+
+
+def test_response_bytes_rejects_missing_content_type():
+    """Responses without a Content-Type are refused."""
+    with pytest.raises(ValueError, match="No response content-type"):
+        _response_bytes(_HeaderOnlyResponse({}))
+
+
+def test_response_bytes_rejects_oversized_content_length():
+    """A Content-Length above the budget is refused before streaming."""
+    response = _HeaderOnlyResponse(
+        {
+            "Content-Type": "text/html",
+            "Content-Length": str(MAX_RESPONSE_BYTES + 1),
+        }
+    )
+
+    with pytest.raises(ValueError, match="exceeds max size"):
+        _response_bytes(response)
+
+
+def test_response_bytes_accepts_valid_content_length():
+    """A Content-Length within budget passes the header check."""
+    response = _HeaderOnlyResponse(
+        {
+            "Content-Type": "text/html",
+            "Content-Length": "1024",
+        }
+    )
+
+    assert _response_bytes(response) == b""
+
+
+def test_response_bytes_skips_empty_chunks():
+    """Empty stream chunks are skipped without truncating the body."""
+    response = _ChunkedResponse([b"a", b"", b"b"], MonotonicClock())
+
+    assert _response_bytes(response) == b"ab"
+
+
+def test_request_timeout_exhausted():
+    """A fully consumed deadline refuses to schedule another request."""
+    with pytest.raises(ValueError, match="Fetch exceeded total time budget"):
+        _request_timeout(0.0)
+
+
+def test_follow_redirects_rejects_unexpected_status(
+    monkeypatch, requests_mock
+):
+    """Non-redirect error statuses surface as fetch errors."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"good.example.com"},
+    )
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _public_addrinfo,
+    )
+    requests_mock.get(
+        "https://good.example.com/page",
+        status_code=500,
+        headers={"Content-Type": "text/html"},
+    )
+
+    with pytest.raises(ValueError, match="Unexpected status code"):
+        get_product_nutritional_info_from_url("https://good.example.com/page")
+
+
+def test_follow_redirects_rejects_empty_location(monkeypatch, requests_mock):
+    """Redirects without a Location value fail closed."""
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder._ALLOWED_SCRAPER_HOSTS",
+        {"good.example.com"},
+    )
+    monkeypatch.setattr(
+        "apps.foods.nutrition_facts_finder.socket.getaddrinfo",
+        _public_addrinfo,
+    )
+    requests_mock.get(
+        "https://good.example.com/page",
+        status_code=302,
+        headers={"Content-Type": "text/html", "Location": ""},
+    )
+
+    with pytest.raises(
+        ValueError, match="Redirect Location header missing value"
+    ):
+        get_product_nutritional_info_from_url("https://good.example.com/page")

--- a/backend/tests/foods/test_coverage_completion_schema.py
+++ b/backend/tests/foods/test_coverage_completion_schema.py
@@ -19,6 +19,7 @@ from apps.foods.schema import (
     FoodMutation,
     FoodProductType,
     FoodQuery,
+    RecipeIngredientType,
     RecipeMutation,
     RecipeQuery,
     RecipeType,
@@ -89,7 +90,11 @@ def test_food_product_query_success_and_missing_paths(mocker):
     """Cover food product query success and missing paths."""
     obj = mocker.Mock()
     mapped = mocker.Mock()
-    mocker.patch.object(FoodProduct.objects, "get", return_value=obj)
+    queryset = mocker.Mock()
+    queryset.get.return_value = obj
+    mocker.patch.object(
+        FoodProduct.objects, "prefetch_related", return_value=queryset
+    )
     converter = mocker.patch.object(
         FoodProductType, "from_model", return_value=mapped
     )
@@ -97,9 +102,7 @@ def test_food_product_query_success_and_missing_paths(mocker):
     assert FoodQuery().food_product(_info(_user()), "1") is mapped
     converter.assert_called_once_with(obj)
 
-    mocker.patch.object(
-        FoodProduct.objects, "get", side_effect=FoodProduct.DoesNotExist
-    )
+    queryset.get.side_effect = FoodProduct.DoesNotExist
     assert FoodQuery().food_product(_info(_user()), "404") is None
 
 
@@ -120,7 +123,27 @@ def test_food_product_type_servings_converts_ordered_models(mocker):
     converter = mocker.patch(
         "apps.foods.schema.ServingType.from_model", return_value=mapped
     )
-    value = SimpleNamespace(id=7)
+    value = SimpleNamespace(id=7, model=None)
+
+    assert FoodProductType.servings(value) == [mapped]
+    converter.assert_called_once_with(serving)
+
+
+def test_recipe_ingredient_type_food_label_empty_without_model():
+    """A model-less ingredient wrapper yields an empty label."""
+    assert RecipeIngredientType.food_label(SimpleNamespace(model=None)) == ""
+
+
+def test_food_product_type_servings_uses_prefetched_models(mocker):
+    """Cover servings resolver model-present path."""
+    serving = mocker.Mock()
+    model = mocker.Mock()
+    model.servings.all.return_value = [serving]
+    mapped = mocker.Mock()
+    converter = mocker.patch(
+        "apps.foods.schema.ServingType.from_model", return_value=mapped
+    )
+    value = SimpleNamespace(id=7, model=model)
 
     assert FoodProductType.servings(value) == [mapped]
     converter.assert_called_once_with(serving)
@@ -139,7 +162,23 @@ def test_recipe_type_ingredients_converts_ordered_models(mocker):
         "apps.foods.schema.RecipeIngredientType.from_model",
         return_value=mapped,
     )
-    value = SimpleNamespace(id=8)
+    value = SimpleNamespace(id=8, model=None)
+
+    assert RecipeType.ingredients(value) == [mapped]
+    converter.assert_called_once_with(ingredient)
+
+
+def test_recipe_type_ingredients_uses_prefetched_models(mocker):
+    """Cover ingredients resolver model-present path."""
+    ingredient = mocker.Mock()
+    model = mocker.Mock()
+    model.ingredients.all.return_value = [ingredient]
+    mapped = mocker.Mock()
+    converter = mocker.patch(
+        "apps.foods.schema.RecipeIngredientType.from_model",
+        return_value=mapped,
+    )
+    value = SimpleNamespace(id=8, model=model)
 
     assert RecipeType.ingredients(value) == [mapped]
     converter.assert_called_once_with(ingredient)

--- a/backend/tests/foods/test_recipe_schema.py
+++ b/backend/tests/foods/test_recipe_schema.py
@@ -193,6 +193,23 @@ class TestRecipeQuery:
         assert result.errors is None
         assert len(captured) == 1
 
+    def test_recipes_inline_fragment_selection_walk(self, mocker):
+        """Nameless inline fragments still walk their nested selections."""
+        user = _create_user("rq-inline-fragment@test.com")
+        mock_context = mocker.Mock()
+        mock_context.request.user = user
+        Recipe.objects.create(
+            name="Inline", size=100, size_unit="g", num_servings=1
+        )
+
+        result = schema.execute_sync(
+            "{ recipes { id ... on RecipeType { name } } }",
+            context_value=mock_context,
+        )
+
+        assert result.errors is None
+        assert result.data["recipes"][0]["name"] == "Inline"
+
     def test_recipes_query(self, mocker):
         """Test listing recipes."""
         # Given an authenticated user and some recipes

--- a/backend/tests/plans/test_coverage_completion.py
+++ b/backend/tests/plans/test_coverage_completion.py
@@ -12,6 +12,8 @@ from apps.plans.schema import (
     DayType,
     PlanMutation,
     PlanQuery,
+    WeekPlanType,
+    _day_tdee,
     _validated_week_plan_parameters,
 )
 
@@ -19,7 +21,8 @@ from apps.plans.schema import (
 def _info(user):
     """Build the request context shape consumed by GraphQL helpers."""
     return SimpleNamespace(
-        context=SimpleNamespace(request=SimpleNamespace(user=user))
+        context=SimpleNamespace(request=SimpleNamespace(user=user)),
+        selected_fields=[],
     )
 
 
@@ -52,15 +55,27 @@ def test_plan_queries_return_none_when_owned_object_is_missing(
     mocker, resolver, model, owner_filter
 ):
     """Owned-object lookups translate model absence into nullable results."""
+    user = _authenticated_user()
+    queryset_mock = mocker.Mock()
+    queryset_mock.get.side_effect = model.DoesNotExist
+    filter_mock = mocker.patch.object(
+        model.objects, "filter", return_value=queryset_mock
+    )
     get_mock = mocker.patch.object(
         model.objects, "get", side_effect=model.DoesNotExist
     )
-    user = _authenticated_user()
 
     result = getattr(PlanQuery(), resolver)(_info(user), "404")
 
     assert result is None
-    get_mock.assert_called_once_with(pk="404", **{owner_filter: user})
+    if resolver == "week_plan":
+        filter_mock.assert_called_once_with(pk="404", user=user)
+        queryset_mock.get.assert_called_once_with()
+    elif resolver == "day":
+        filter_mock.assert_called_once_with(plan__user=user)
+        queryset_mock.get.assert_called_once_with(pk="404")
+    else:
+        get_mock.assert_called_once_with(pk="404", day__plan__user=user)
 
 
 @pytest.mark.parametrize(
@@ -85,17 +100,26 @@ def test_plan_queries_convert_found_owned_objects(
 ):
     """Owned-object query success paths delegate to their GraphQL wrappers."""
     obj = mocker.Mock()
-    get_mock = mocker.patch.object(model.objects, "get", return_value=obj)
     converted = mocker.Mock()
     converter = mocker.patch(
         f"{graphql_type}.from_model", return_value=converted
     )
-
     user = _authenticated_user()
+    queryset_mock = mocker.Mock()
+    queryset_mock.get.return_value = obj
+    filter_mock = mocker.patch.object(
+        model.objects, "filter", return_value=queryset_mock
+    )
+    get_mock = mocker.patch.object(model.objects, "get", return_value=obj)
+
     result = getattr(PlanQuery(), resolver)(_info(user), "1")
 
     assert result is converted
-    get_mock.assert_called_once_with(pk="1", **{owner_filter: user})
+    if resolver == "week_plan":
+        filter_mock.assert_called_once_with(pk="1", user=user)
+        queryset_mock.get.assert_called_once_with()
+    else:
+        get_mock.assert_called_once_with(pk="1", day__plan__user=user)
     converter.assert_called_once_with(obj)
 
 
@@ -118,13 +142,87 @@ def test_day_type_orders_and_converts_intakes(mocker):
     filter_mock = mocker.patch.object(
         Intake.objects, "filter", return_value=queryset
     )
-    day = SimpleNamespace(id=2)
+    day = SimpleNamespace(id=2, model=None)
 
     result = DayType.intakes(day)
 
     filter_mock.assert_called_once_with(day_id=2)
     queryset.order_by.assert_called_once_with("meal_order", "created_at")
     assert [str(item.id) for item in result] == ["1"]
+
+
+def test_day_tdee_untracked_uses_bmr_rate():
+    """Untracked days resolve TDEE straight from the plan BMR."""
+    day = SimpleNamespace(
+        tracked=False,
+        plan=SimpleNamespace(
+            measurement=SimpleNamespace(bmr=Decimal("2000")),
+            EXERCISE_RATE=Decimal("1.375"),
+        ),
+    )
+
+    assert _day_tdee(day) == (Decimal("2000") * Decimal("1.375")).normalize()
+
+
+def test_day_tdee_falls_back_to_eat_when_unannotated():
+    """Days without the batched eat_total annotation use the plain sum."""
+    day = SimpleNamespace(
+        tracked=True,
+        steps=SimpleNamespace(kcals=Decimal("100")),
+        energy_kcal=Decimal("2000"),
+        eat=Decimal("300"),
+        plan=SimpleNamespace(
+            measurement=SimpleNamespace(bmr=Decimal("2000")),
+            EXERCISE_RATE=Decimal("1.375"),
+        ),
+    )
+
+    assert _day_tdee(day) == Decimal("2600")
+
+
+def test_day_type_tdee_returns_zero_without_model():
+    """A wrapper without a model yields a zero TDEE instead of querying."""
+    assert DayType.tdee(SimpleNamespace(model=None)) == 0.0
+
+
+def test_week_plan_type_days_fallback_queries_without_model(mocker):
+    """Days resolve per-object when the wrapper has no prefetched model."""
+    day = mocker.Mock()
+    queryset = mocker.Mock()
+    queryset.order_by.return_value = [day]
+    filter_mock = mocker.patch.object(
+        Day.objects, "filter", return_value=queryset
+    )
+    converted = mocker.Mock()
+    mocker.patch(
+        "apps.plans.schema.DayType.from_model", return_value=converted
+    )
+    value = SimpleNamespace(id=9, model=None)
+
+    assert WeekPlanType.days(value) == [converted]
+    filter_mock.assert_called_once_with(plan_id=9)
+
+
+def test_week_plan_type_scalars_return_zero_without_model():
+    """TWEE and energy scalars fail soft on model-less wrappers."""
+    value = SimpleNamespace(model=None)
+
+    assert WeekPlanType.twee(value) == 0.0
+    assert WeekPlanType.energy_kcal_goal(value) == 0.0
+    assert WeekPlanType.energy_kcal(value) == 0.0
+
+
+def test_week_plan_type_energy_scalars_read_model_values():
+    """Energy scalars surface the model values when the model is present."""
+    value = SimpleNamespace(
+        model=SimpleNamespace(
+            energy_kcal_goal=Decimal("2000"),
+            energy_kcal=Decimal("1500"),
+        )
+    )
+
+    assert WeekPlanType.energy_kcal_goal(value) == 2000.0
+    assert WeekPlanType.energy_kcal(value) == 1500.0
 
 
 def test_week_plan_validation_rejects_mismatched_daily_inputs(mocker):

--- a/backend/tests/plans/test_schema.py
+++ b/backend/tests/plans/test_schema.py
@@ -224,6 +224,38 @@ class TestPlanGraphQLBudget:
         )
         assert day_tdee == float(day.tdee)
 
+    def test_week_plan_singular_with_days_prefetches(self, mocker):
+        """The single-plan path hydrates days with TDEE dependencies."""
+        user, plan = _create_user_and_plan("plan-singular-prefetch@test.com")
+        mock_context = mocker.Mock()
+        mock_context.request.user = user
+
+        result = schema.execute_sync(
+            '{ weekPlan(id: "%s") { id days { id tdee } } }' % plan.id,
+            context_value=mock_context,
+        )
+
+        assert result.errors is None
+        week = result.data["weekPlan"]
+        assert week["id"] == str(plan.id)
+        assert len(week["days"]) == 7
+
+    def test_day_singular_with_tdee_and_intakes_hydrates(self, mocker):
+        """The single-day path hydrates only when nested fields are asked."""
+        user, plan = _create_user_and_plan("plan-singular-day@test.com")
+        day = Day.objects.filter(plan=plan).first()
+        mock_context = mocker.Mock()
+        mock_context.request.user = user
+
+        result = schema.execute_sync(
+            '{ day(id: "%s") { id tdee intakes { id meal } } }' % day.id,
+            context_value=mock_context,
+        )
+
+        assert result.errors is None
+        assert result.data["day"]["id"] == str(day.id)
+        assert result.data["day"]["intakes"] == []
+
     def test_week_plans_fragment_query_has_bounded_budget(self, mocker):
         """Named fragment day selections keep the hydration bounded."""
         fragment_query = (

--- a/backend/tests/test_docker_release_contract.py
+++ b/backend/tests/test_docker_release_contract.py
@@ -13,7 +13,9 @@ def test_backend_docker_release_target_orders_contract_before_push():
         makefile,
         flags=re.MULTILINE,
     )
-    assert match, "Expected docker-build-contract-tag-push target in backend/Makefile."
+    assert (
+        match
+    ), "Expected docker-build-contract-tag-push target in backend/Makefile."
 
     commands = match.group("body").splitlines()
     body_text = "\n".join(commands)
@@ -23,7 +25,9 @@ def test_backend_docker_release_target_orders_contract_before_push():
     push = body_text.index("docker-push")
     assert build < contract < tag < push
 
-    circleci_config = (repo_root / ".circleci" / "config.yml").read_text(encoding="utf-8")
+    circleci_config = (repo_root / ".circleci" / "config.yml").read_text(
+        encoding="utf-8"
+    )
     assert (
         "make docker-build-contract-tag-push" in circleci_config
     ), "Expected CircleCI backend job to use the contract-aware docker target."

--- a/backend/tests/test_docker_release_contract.py
+++ b/backend/tests/test_docker_release_contract.py
@@ -1,0 +1,29 @@
+"""Regression checks for backend docker release target ordering."""
+
+import re
+from pathlib import Path
+
+
+def test_backend_docker_release_target_orders_contract_before_push():
+    """Guard against regressions where publish order changes."""
+    repo_root = Path(__file__).resolve().parents[2]
+    makefile = (repo_root / "backend" / "Makefile").read_text(encoding="utf-8")
+    match = re.search(
+        r"^docker-build-contract-tag-push:\n(?P<body>(?:\t.*\n)+)",
+        makefile,
+        flags=re.MULTILINE,
+    )
+    assert match, "Expected docker-build-contract-tag-push target in backend/Makefile."
+
+    commands = match.group("body").splitlines()
+    body_text = "\n".join(commands)
+    build = body_text.index("docker-build")
+    contract = body_text.index("docker-contract-test")
+    tag = body_text.index("docker-tag")
+    push = body_text.index("docker-push")
+    assert build < contract < tag < push
+
+    circleci_config = (repo_root / ".circleci" / "config.yml").read_text(encoding="utf-8")
+    assert (
+        "make docker-build-contract-tag-push" in circleci_config
+    ), "Expected CircleCI backend job to use the contract-aware docker target."


### PR DESCRIPTION
## Summary
- Remove passwordless sudo configuration from the backend Docker image and expose listeners on 8080/9000 for public and health traffic respectively.
- Enforce non-root, non-escalating, and no-new-privileges Helm defaults for the backend container.
- Use explicit public and health container ports in the deployment, route Service traffic to the public listener, and keep probes on the health listener.
- Add Helm and Docker contract test targets with rendered-template validation and Dockerfile/static/runtime checks.

## Test Evidence
- make chart-contract-test
- make black
- make contract-tests
  - chart contract checks pass.
  - docker contract test fails in this environment due Docker daemon permission (`/var/run/docker.sock` is inaccessible to this process).

## Additional Notes
- The chart test script installs/uses a local Helm binary when system Helm is unavailable, without sudo.

Closes #379
Closes #380