### PR TITLE
Fix meal validation and bounded query resolvers

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,5 +1,9 @@
 IMAGE_NAME?=luismunozvillarreal/nutrition-backend
 TAG?=latest
+DJANGO_SETTINGS_MODULE?=config.settings
+SECRET_KEY?=insecure-local-test-secret
+GEMINI_API_KEY?=local-test-gemini-key
+DATABASE_URL?=sqlite:///db.sqlite3
 
 .PHONY: install python-checks pytest bandit flake8 black mypy pylint pylint-tests pydocstyle pydocstyle-tests docker-build docker-tag docker-push restore-db migrations-check migrate ci-migrations
 
@@ -9,6 +13,10 @@ install:
 python-checks: pytest bandit flake8 black-fix mypy pylint pylint-tests pydocstyle pydocstyle-tests
 
 pytest:
+	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) \
+	SECRET_KEY=$(SECRET_KEY) \
+	GEMINI_API_KEY=$(GEMINI_API_KEY) \
+	DATABASE_URL=$(DATABASE_URL) \
 	uv run pytest -n 4 tests ../.circleci/scripts $(ARGS)
 
 bandit:

--- a/backend/apps/foods/schema.py
+++ b/backend/apps/foods/schema.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import strawberry
 from django.db import models, transaction
+from django.db.models import Prefetch
 from strawberry.types import Info
 
 from apps.foods.models import (
@@ -219,6 +220,12 @@ class FoodProductType:
         Returns:
             list[ServingType]: list of servings.
         """
+        model = getattr(self, "_model", None)
+        if model is not None:
+            return [
+                ServingType.from_model(s)
+                for s in model.servings.all()  # type: ignore[attr-defined]
+            ]
         return [
             ServingType.from_model(s)
             for s in Serving.objects.filter(food_id=self.id).order_by("id")
@@ -234,7 +241,7 @@ class FoodProductType:
         Returns:
             FoodProductType: GraphQL type.
         """
-        return FoodProductType(
+        wrapped = FoodProductType(
             id=strawberry.ID(str(obj.id)),
             brand=obj.brand,
             name=obj.name,
@@ -267,6 +274,8 @@ class FoodProductType:
             ),
             salt_g=float(obj.salt_g) if obj.salt_g is not None else None,
         )
+        wrapped._model = obj  # type: ignore[attr-defined]
+        return wrapped
 
 
 @strawberry.type
@@ -289,7 +298,14 @@ class FoodQuery:
 
         return [
             FoodProductType.from_model(fp)
-            for fp in FoodProduct.objects.all().order_by("name")
+            for fp in FoodProduct.objects.prefetch_related(
+                Prefetch(
+                    "servings",
+                    queryset=Serving.objects.select_related("food").order_by(
+                        "id"
+                    ),
+                )
+            ).order_by("name")
         ]
 
     @strawberry.field
@@ -310,7 +326,16 @@ class FoodQuery:
             return None
 
         try:
-            return FoodProductType.from_model(FoodProduct.objects.get(pk=id))
+            return FoodProductType.from_model(
+                FoodProduct.objects.prefetch_related(
+                    Prefetch(
+                        "servings",
+                        queryset=Serving.objects.select_related(
+                            "food"
+                        ).order_by("id"),
+                    )
+                ).get(pk=id)
+            )
         except FoodProduct.DoesNotExist:
             return None
 
@@ -698,7 +723,6 @@ class RecipeIngredientType:
     id: strawberry.ID
     recipe_id: strawberry.ID
     food_id: strawberry.ID
-    food_label: str
     num_servings: float
     energy_kcal: float
     protein_g: float
@@ -715,17 +739,29 @@ class RecipeIngredientType:
         Returns:
             RecipeIngredientType: GraphQL type.
         """
-        return RecipeIngredientType(
+        wrapped = RecipeIngredientType(
             id=strawberry.ID(str(obj.id)),
             recipe_id=strawberry.ID(str(obj.recipe_id)),
             food_id=strawberry.ID(str(obj.food_id)),
-            food_label=str(obj.food),
             num_servings=float(obj.num_servings),
             energy_kcal=float(obj.energy_kcal),
             protein_g=float(obj.protein_g),
             fat_g=float(obj.fat_g),
             carbs_g=float(obj.carbs_g),
         )
+        wrapped._model = obj  # type: ignore[attr-defined]
+        return wrapped
+
+    @strawberry.field
+    def food_label(self) -> str:
+        """Resolve ingredient label lazily to avoid eager food loading."""
+        model = getattr(self, "_model", None)
+        if model is None:
+            return ""
+        cached_food = model._state.fields_cache.get("food")
+        if cached_food is not None:
+            return str(cached_food)
+        return str(model.food)
 
 
 @strawberry.type
@@ -756,6 +792,12 @@ class RecipeType:
         Returns:
             list[RecipeIngredientType]: list of ingredients.
         """
+        model = getattr(self, "_model", None)
+        if model is not None:
+            return [
+                RecipeIngredientType.from_model(i)
+                for i in model.ingredients.all()  # type: ignore[attr-defined]
+            ]
         return [
             RecipeIngredientType.from_model(i)
             for i in RecipeIngredient.objects.filter(
@@ -773,7 +815,7 @@ class RecipeType:
         Returns:
             RecipeType: GraphQL type.
         """
-        return RecipeType(
+        wrapped = RecipeType(
             id=strawberry.ID(str(obj.id)),
             brand=obj.brand,
             name=obj.name,
@@ -803,6 +845,8 @@ class RecipeType:
             ),
             salt_g=float(obj.salt_g) if obj.salt_g is not None else None,
         )
+        wrapped._model = obj  # type: ignore[attr-defined]
+        return wrapped
 
 
 @strawberry.type
@@ -824,7 +868,15 @@ class RecipeQuery:
             return []
         return [
             RecipeType.from_model(r)
-            for r in Recipe.objects.all().order_by("name")
+            for r in Recipe.objects.prefetch_related(
+                Prefetch(
+                    "ingredients",
+                    queryset=RecipeIngredient.objects.select_related(
+                        "food"
+                    ).order_by("id"),
+                ),
+                "ingredients__food",
+            ).order_by("name")
         ]
 
     @strawberry.field
@@ -842,7 +894,17 @@ class RecipeQuery:
         if user is None or not user.is_authenticated:
             return None
         try:
-            return RecipeType.from_model(Recipe.objects.get(pk=id))
+            return RecipeType.from_model(
+                Recipe.objects.prefetch_related(
+                    Prefetch(
+                        "ingredients",
+                        queryset=RecipeIngredient.objects.select_related(
+                            "food"
+                        ).order_by("id"),
+                    ),
+                    "ingredients__food",
+                ).get(pk=id)
+            )
         except Recipe.DoesNotExist:
             return None
 

--- a/backend/apps/foods/schema.py
+++ b/backend/apps/foods/schema.py
@@ -2,6 +2,7 @@
 
 import datetime
 import math
+from collections.abc import Iterable
 from decimal import Decimal
 from typing import cast
 
@@ -277,13 +278,30 @@ class FoodProductType:
 
 
 def _requested_field_names(info: Info) -> set[str]:
-    """Return the GraphQL field names selected on the current field's type."""
+    """Return the GraphQL field names selected on the current field's type.
+
+    Recurses into named and inline fragment selections so conditional
+    hydration stays bounded for fragment-based queries too.
+
+    Args:
+        info (Info): GraphQL execution info.
+
+    Returns:
+        set[str]: names of selected fields on the current type.
+    """
     names: set[str] = set()
-    for field in info.selected_fields:
-        for selection in field.selections:
+
+    def _visit(selections: Iterable[object]) -> None:
+        for selection in selections:
             name = getattr(selection, "name", None)
             if name:
                 names.add(name)
+            nested = getattr(selection, "selections", None)
+            if nested:
+                _visit(nested)
+
+    for field in info.selected_fields:
+        _visit(field.selections)
     return names
 
 
@@ -772,9 +790,6 @@ class RecipeIngredientType:
         model = self.model
         if model is None:
             return ""
-        cached_food = model.__dict__.get("food")
-        if cached_food is not None:
-            return str(cached_food)
         return str(model.food)
 
 

--- a/backend/apps/foods/schema.py
+++ b/backend/apps/foods/schema.py
@@ -212,6 +212,7 @@ class FoodProductType:
     sugars_g: float | None
     fibre_g: float | None
     salt_g: float | None
+    model: strawberry.Private[FoodProduct | None] = None
 
     @strawberry.field
     def servings(self) -> list[ServingType]:
@@ -220,12 +221,9 @@ class FoodProductType:
         Returns:
             list[ServingType]: list of servings.
         """
-        model = getattr(self, "_model", None)
+        model = self.model
         if model is not None:
-            return [
-                ServingType.from_model(s)
-                for s in model.servings.all()  # type: ignore[attr-defined]
-            ]
+            return [ServingType.from_model(s) for s in model.servings.all()]
         return [
             ServingType.from_model(s)
             for s in Serving.objects.filter(food_id=self.id).order_by("id")
@@ -274,7 +272,7 @@ class FoodProductType:
             ),
             salt_g=float(obj.salt_g) if obj.salt_g is not None else None,
         )
-        wrapped._model = obj  # type: ignore[attr-defined]
+        wrapped.model = obj
         return wrapped
 
 
@@ -728,6 +726,7 @@ class RecipeIngredientType:
     protein_g: float
     fat_g: float
     carbs_g: float
+    model: strawberry.Private[RecipeIngredient | None] = None
 
     @staticmethod
     def from_model(obj: RecipeIngredient) -> "RecipeIngredientType":
@@ -749,16 +748,20 @@ class RecipeIngredientType:
             fat_g=float(obj.fat_g),
             carbs_g=float(obj.carbs_g),
         )
-        wrapped._model = obj  # type: ignore[attr-defined]
+        wrapped.model = obj
         return wrapped
 
     @strawberry.field
     def food_label(self) -> str:
-        """Resolve ingredient label lazily to avoid eager food loading."""
-        model = getattr(self, "_model", None)
+        """Resolve ingredient label lazily to avoid eager food loading.
+
+        Returns:
+            str: human-readable label.
+        """
+        model = self.model
         if model is None:
             return ""
-        cached_food = model._state.fields_cache.get("food")
+        cached_food = model.__dict__.get("food")
         if cached_food is not None:
             return str(cached_food)
         return str(model.food)
@@ -784,6 +787,7 @@ class RecipeType:
     sugars_g: float | None
     fibre_g: float | None
     salt_g: float | None
+    model: strawberry.Private[Recipe | None] = None
 
     @strawberry.field
     def ingredients(self) -> list[RecipeIngredientType]:
@@ -792,11 +796,11 @@ class RecipeType:
         Returns:
             list[RecipeIngredientType]: list of ingredients.
         """
-        model = getattr(self, "_model", None)
+        model = self.model
         if model is not None:
             return [
                 RecipeIngredientType.from_model(i)
-                for i in model.ingredients.all()  # type: ignore[attr-defined]
+                for i in model.ingredients.all()
             ]
         return [
             RecipeIngredientType.from_model(i)
@@ -845,7 +849,7 @@ class RecipeType:
             ),
             salt_g=float(obj.salt_g) if obj.salt_g is not None else None,
         )
-        wrapped._model = obj  # type: ignore[attr-defined]
+        wrapped.model = obj
         return wrapped
 
 

--- a/backend/apps/foods/schema.py
+++ b/backend/apps/foods/schema.py
@@ -276,6 +276,17 @@ class FoodProductType:
         return wrapped
 
 
+def _requested_field_names(info: Info) -> set[str]:
+    """Return the GraphQL field names selected on the current field's type."""
+    names: set[str] = set()
+    for field in info.selected_fields:
+        for selection in field.selections:
+            name = getattr(selection, "name", None)
+            if name:
+                names.add(name)
+    return names
+
+
 @strawberry.type
 class FoodQuery:
     """Food queries."""
@@ -294,17 +305,17 @@ class FoodQuery:
         if user is None or not user.is_authenticated:
             return []
 
-        return [
-            FoodProductType.from_model(fp)
-            for fp in FoodProduct.objects.prefetch_related(
+        queryset = FoodProduct.objects.order_by("name")
+        if "servings" in _requested_field_names(info):
+            queryset = queryset.prefetch_related(
                 Prefetch(
                     "servings",
                     queryset=Serving.objects.select_related("food").order_by(
                         "id"
                     ),
                 )
-            ).order_by("name")
-        ]
+            )
+        return [FoodProductType.from_model(fp) for fp in queryset]
 
     @strawberry.field
     def food_product(
@@ -870,18 +881,17 @@ class RecipeQuery:
         user = get_request_user(info.context)
         if user is None or not user.is_authenticated:
             return []
-        return [
-            RecipeType.from_model(r)
-            for r in Recipe.objects.prefetch_related(
+        queryset = Recipe.objects.order_by("name")
+        if "ingredients" in _requested_field_names(info):
+            queryset = queryset.prefetch_related(
                 Prefetch(
                     "ingredients",
                     queryset=RecipeIngredient.objects.select_related(
-                        "food"
+                        "food__food"
                     ).order_by("id"),
-                ),
-                "ingredients__food",
-            ).order_by("name")
-        ]
+                )
+            )
+        return [RecipeType.from_model(r) for r in queryset]
 
     @strawberry.field
     def recipe(self, info: Info, id: strawberry.ID) -> RecipeType | None:
@@ -903,10 +913,9 @@ class RecipeQuery:
                     Prefetch(
                         "ingredients",
                         queryset=RecipeIngredient.objects.select_related(
-                            "food"
+                            "food__food"
                         ).order_by("id"),
                     ),
-                    "ingredients__food",
                 ).get(pk=id)
             )
         except Recipe.DoesNotExist:

--- a/backend/apps/plans/models/intake.py
+++ b/backend/apps/plans/models/intake.py
@@ -330,6 +330,42 @@ class Intake(Nutrients):
         editable=False,
     )
 
+    @classmethod
+    def validate_meal(cls, meal: str) -> str:
+        """Validate and normalize a user-supplied meal token.
+
+        Args:
+            meal (str): The caller-provided meal label.
+
+        Returns:
+            str: Normalized meal token.
+
+        Raises:
+            ValueError: If the meal is not a supported canonical value.
+        """
+        normalized = meal.strip()
+        if normalized not in cls.MEAL_ORDER:
+            raise ValueError(
+                "meal must be one of: "
+                + ", ".join(meal for meal, _ in cls.MEAL_CHOICES)
+            )
+        return normalized
+
+    @classmethod
+    def meal_order_for(cls, meal: str) -> int:
+        """Return the canonical sort order for a validated meal.
+
+        Args:
+            meal (str): Meal token to map.
+
+        Returns:
+            int: Meal order index.
+
+        Raises:
+            ValueError: If the meal is unsupported.
+        """
+        return cls.MEAL_ORDER[cls.validate_meal(meal)]
+
     notes = models.TextField(
         blank=True,
     )
@@ -437,7 +473,8 @@ class Intake(Nutrients):
                     cupboard_locks = lock_intake_cupboard_rows(
                         self, previous, using
                     )
-                    self.meal_order = self.MEAL_ORDER[self.meal]
+                    self.meal = self.validate_meal(self.meal)
+                    self.meal_order = self.meal_order_for(self.meal)
 
                     if previous is not None and self.food is None:
                         removed_food_without_macro_edits = (

--- a/backend/apps/plans/schema.py
+++ b/backend/apps/plans/schema.py
@@ -141,7 +141,7 @@ class DayType:
     protein_g: float
     fat_g: float
     carbs_g: float
-    tdee: float
+    model: strawberry.Private[Day | None] = None
 
     @strawberry.field
     def intakes(self) -> list[IntakeType]:
@@ -150,7 +150,7 @@ class DayType:
         Returns:
             list[IntakeType]: list of intakes.
         """
-        model = getattr(self, "_model", None)
+        model = self.model
         if model is not None:
             return [IntakeType.from_model(i) for i in model.intakes.all()]
         return [
@@ -193,10 +193,20 @@ class DayType:
             protein_g=float(obj.protein_g),
             fat_g=float(obj.fat_g),
             carbs_g=float(obj.carbs_g),
-            tdee=float(obj.tdee) if obj.tdee else 0.0,
         )
-        wrapped._model = obj  # type: ignore[attr-defined]
+        wrapped.model = obj
         return wrapped
+
+    @strawberry.field
+    def tdee(self) -> float:
+        """Resolve total daily energy expenditure when requested.
+
+        Returns:
+            float: total daily energy expenditure.
+        """
+        if self.model is None:
+            return 0.0
+        return float(self.model.tdee) if self.model.tdee else 0.0
 
 
 @strawberry.type
@@ -209,9 +219,7 @@ class WeekPlanType:
     fat_perc: float
     deficit: int
     completed: bool
-    twee: float
-    energy_kcal_goal: float
-    energy_kcal: float
+    model: strawberry.Private[WeekPlan | None] = None
 
     @strawberry.field
     def days(self) -> list[DayType]:
@@ -220,7 +228,7 @@ class WeekPlanType:
         Returns:
             list[DayType]: list of days.
         """
-        model = getattr(self, "_model", None)
+        model = self.model
         if model is not None:
             return [DayType.from_model(d) for d in model.days.all()]
         return [
@@ -247,12 +255,42 @@ class WeekPlanType:
             fat_perc=float(obj.fat_perc),
             deficit=obj.deficit,
             completed=obj.completed,
-            twee=float(obj.twee),
-            energy_kcal_goal=float(obj.energy_kcal_goal),
-            energy_kcal=float(obj.energy_kcal),
         )
-        wrapped._model = obj  # type: ignore[attr-defined]
+        wrapped.model = obj
         return wrapped
+
+    @strawberry.field
+    def twee(self) -> float:
+        """Resolve TWEE when requested.
+
+        Returns:
+            float: total weekly energy expenditure estimate.
+        """
+        if self.model is None:
+            return 0.0
+        return float(self.model.twee)
+
+    @strawberry.field
+    def energy_kcal_goal(self) -> float:
+        """Resolve energy goal when requested.
+
+        Returns:
+            float: weekly energy target.
+        """
+        if self.model is None:
+            return 0.0
+        return float(self.model.energy_kcal_goal)
+
+    @strawberry.field
+    def energy_kcal(self) -> float:
+        """Resolve energy intake when requested.
+
+        Returns:
+            float: weekly accumulated energy intake.
+        """
+        if self.model is None:
+            return 0.0
+        return float(self.model.energy_kcal)
 
 
 @strawberry.type

--- a/backend/apps/plans/schema.py
+++ b/backend/apps/plans/schema.py
@@ -3,6 +3,7 @@
 # pylint: disable=too-few-public-methods
 
 import datetime
+from collections.abc import Iterable
 from decimal import Decimal
 from typing import cast
 
@@ -35,13 +36,30 @@ _DAY_DEPENDENT_FIELDS = frozenset(
 
 
 def _requested_field_names(info: Info) -> set[str]:
-    """Return the GraphQL field names selected on the current field's type."""
+    """Return the GraphQL field names selected on the current field's type.
+
+    Recurses into named and inline fragment selections so conditional
+    hydration stays bounded for fragment-based queries too.
+
+    Args:
+        info (Info): GraphQL execution info.
+
+    Returns:
+        set[str]: names of selected fields on the current type.
+    """
     names: set[str] = set()
-    for field in info.selected_fields:
-        for selection in field.selections:
+
+    def _visit(selections: Iterable[object]) -> None:
+        for selection in selections:
             name = getattr(selection, "name", None)
             if name:
                 names.add(name)
+            nested = getattr(selection, "selections", None)
+            if nested:
+                _visit(nested)
+
+    for field in info.selected_fields:
+        _visit(field.selections)
     return names
 
 
@@ -436,15 +454,11 @@ class PlanQuery:
         if user is None or not user.is_authenticated:
             return None
 
+        queryset = Day.objects.filter(plan__user=user)
+        if _requested_field_names(info) & {"intakes", "tdee"}:
+            queryset = _day_queryset().filter(plan__user=user)
         try:
-            obj = Day.objects.prefetch_related(
-                Prefetch(
-                    "intakes",
-                    queryset=Intake.objects.order_by(
-                        "meal_order", "created_at"
-                    ),
-                )
-            ).get(pk=id, plan__user=user)
+            obj = queryset.get(pk=id)
         except Day.DoesNotExist:
             return None
         return DayType.from_model(obj)

--- a/backend/apps/plans/schema.py
+++ b/backend/apps/plans/schema.py
@@ -9,6 +9,7 @@ from typing import cast
 import strawberry
 from django.conf import settings
 from django.db import models, router, transaction
+from django.db.models import Prefetch
 from strawberry.types import Info
 
 from apps.libs.graphql import (
@@ -149,9 +150,9 @@ class DayType:
         Returns:
             list[IntakeType]: list of intakes.
         """
-        # We need to access the django instance.
-        # But `self` is a DayType wrapper.
-        # We handle this by querying the intakes for this ID.
+        model = getattr(self, "_model", None)
+        if model is not None:
+            return [IntakeType.from_model(i) for i in model.intakes.all()]
         return [
             IntakeType.from_model(i)
             for i in Intake.objects.filter(day_id=self.id).order_by(
@@ -172,7 +173,7 @@ class DayType:
         Returns:
             DayType: GraphQL type.
         """
-        return DayType(
+        wrapped = DayType(
             id=strawberry.ID(str(obj.id)),
             plan_id=obj.plan_id,
             day=obj.day.isoformat(),
@@ -194,6 +195,8 @@ class DayType:
             carbs_g=float(obj.carbs_g),
             tdee=float(obj.tdee) if obj.tdee else 0.0,
         )
+        wrapped._model = obj  # type: ignore[attr-defined]
+        return wrapped
 
 
 @strawberry.type
@@ -217,6 +220,9 @@ class WeekPlanType:
         Returns:
             list[DayType]: list of days.
         """
+        model = getattr(self, "_model", None)
+        if model is not None:
+            return [DayType.from_model(d) for d in model.days.all()]
         return [
             DayType.from_model(d)
             for d in Day.objects.filter(plan_id=int(str(self.id))).order_by(
@@ -234,7 +240,7 @@ class WeekPlanType:
         Returns:
             WeekPlanType: GraphQL type.
         """
-        return WeekPlanType(
+        wrapped = WeekPlanType(
             id=strawberry.ID(str(obj.id)),
             start_date=obj.start_date.isoformat(),
             protein_g_kg=float(obj.protein_g_kg),
@@ -245,6 +251,8 @@ class WeekPlanType:
             energy_kcal_goal=float(obj.energy_kcal_goal),
             energy_kcal=float(obj.energy_kcal),
         )
+        wrapped._model = obj  # type: ignore[attr-defined]
+        return wrapped
 
 
 @strawberry.type
@@ -267,7 +275,21 @@ class PlanQuery:
 
         return [
             WeekPlanType.from_model(p)
-            for p in WeekPlan.objects.filter(user=user).order_by("-start_date")
+            for p in WeekPlan.objects.filter(user=user)
+            .prefetch_related(
+                Prefetch(
+                    "days",
+                    queryset=Day.objects.prefetch_related(
+                        Prefetch(
+                            "intakes",
+                            queryset=Intake.objects.order_by(
+                                "meal_order", "created_at"
+                            ),
+                        )
+                    ).order_by("day"),
+                )
+            )
+            .order_by("-start_date")
         ]
 
     @strawberry.field
@@ -286,7 +308,19 @@ class PlanQuery:
             return None
 
         try:
-            obj = WeekPlan.objects.get(pk=id, user=user)
+            obj = WeekPlan.objects.prefetch_related(
+                Prefetch(
+                    "days",
+                    queryset=Day.objects.prefetch_related(
+                        Prefetch(
+                            "intakes",
+                            queryset=Intake.objects.order_by(
+                                "meal_order", "created_at"
+                            ),
+                        )
+                    ).order_by("day"),
+                )
+            ).get(pk=id, user=user)
         except WeekPlan.DoesNotExist:
             return None
         return WeekPlanType.from_model(obj)
@@ -307,7 +341,14 @@ class PlanQuery:
             return None
 
         try:
-            obj = Day.objects.get(pk=id, plan__user=user)
+            obj = Day.objects.prefetch_related(
+                Prefetch(
+                    "intakes",
+                    queryset=Intake.objects.order_by(
+                        "meal_order", "created_at"
+                    ),
+                )
+            ).get(pk=id, plan__user=user)
         except Day.DoesNotExist:
             return None
         return DayType.from_model(obj)
@@ -558,6 +599,7 @@ class PlanMutation:
             "numServings",
             Intake._meta.get_field("num_servings"),
         )
+        validated_meal = Intake.validate_meal(meal)
 
         try:
             day = Day.objects.get(pk=day_id, plan__user=user)
@@ -568,7 +610,7 @@ class PlanMutation:
         # This mirrors the flexibility of Django admin for Intakes.
         kwargs = {
             "day": day,
-            "meal": meal,
+            "meal": validated_meal,
             "num_servings": validated_num_servings,
         }
 
@@ -665,7 +707,7 @@ class PlanMutation:
                         )
                     )
 
-        obj.meal = meal
+        obj.meal = Intake.validate_meal(meal)
         obj.num_servings = validated_num_servings
 
         # Food-backed nutrients are derived and cannot be directly modified.

--- a/backend/apps/plans/schema.py
+++ b/backend/apps/plans/schema.py
@@ -22,6 +22,75 @@ from apps.measurements.models import Measurement
 from apps.plans.locks import lock_plan_aggregate_rows
 from apps.plans.models import Day, Intake, WeekPlan
 
+# WeekPlanType fields that traverse the days relation (and therefore need the
+# batched day prefetch to avoid per-plan query growth).
+_DAY_DEPENDENT_FIELDS = frozenset(
+    {
+        "days",
+        "twee",
+        "energyKcalGoal",
+        "energyKcal",
+    }
+)
+
+
+def _requested_field_names(info: Info) -> set[str]:
+    """Return the GraphQL field names selected on the current field's type."""
+    names: set[str] = set()
+    for field in info.selected_fields:
+        for selection in field.selections:
+            name = getattr(selection, "name", None)
+            if name:
+                names.add(name)
+    return names
+
+
+def _day_queryset() -> models.QuerySet:
+    """Build the Day queryset with all TDEE dependencies preloaded.
+
+    Selects the plan measurement and reverse one-to-one steps, prefetches
+    intakes, and annotates the exercise calories aggregate so ``tdee`` and
+    ``twee`` never issue per-day SQL.
+    """
+    return (
+        Day.objects.select_related("plan__measurement", "steps")
+        .prefetch_related(
+            Prefetch(
+                "intakes",
+                queryset=Intake.objects.order_by("meal_order", "created_at"),
+            )
+        )
+        .annotate(eat_total=models.Sum("exercises__kcals"))
+        .order_by("day")
+    )
+
+
+def _day_tdee(day: Day) -> Decimal:
+    """Compute a day's TDEE from prefetched or annotated data.
+
+    Mirrors ``Day.tdee`` but consumes the batched plan measurement, steps,
+    intakes, and the annotated exercise total instead of issuing queries.
+
+    Args:
+        day (Day): the day model instance.
+
+    Returns:
+        Decimal: the total daily energy expenditure.
+    """
+    if not day.tracked:
+        return (day.plan.measurement.bmr * day.plan.EXERCISE_RATE).normalize()
+
+    if hasattr(day, "steps"):
+        neat = day.steps.kcals
+    else:
+        neat = Decimal("0")
+    tef = day.energy_kcal * Decimal("0.1")
+    if hasattr(day, "eat_total"):
+        eat_total = Decimal(day.eat_total or 0)
+    else:
+        eat_total = Decimal(day.eat or 0)
+    return day.plan.measurement.bmr + neat + tef + eat_total
+
 
 def _validated_week_plan_parameters(
     measurement: Measurement,
@@ -206,7 +275,7 @@ class DayType:
         """
         if self.model is None:
             return 0.0
-        return float(self.model.tdee) if self.model.tdee else 0.0
+        return float(_day_tdee(self.model))
 
 
 @strawberry.type
@@ -230,6 +299,8 @@ class WeekPlanType:
         """
         model = self.model
         if model is not None:
+            # The conditional week_plans/week_plan prefetch builds this cache
+            # with _day_queryset(), so TDEE dependencies are already loaded.
             return [DayType.from_model(d) for d in model.days.all()]
         return [
             DayType.from_model(d)
@@ -268,7 +339,10 @@ class WeekPlanType:
         """
         if self.model is None:
             return 0.0
-        return float(self.model.twee)
+        total = Decimal("0")
+        for day in self.model.days.all():
+            total += _day_tdee(day)
+        return float(total)
 
     @strawberry.field
     def energy_kcal_goal(self) -> float:
@@ -311,23 +385,14 @@ class PlanQuery:
         if user is None or not user.is_authenticated:
             return []
 
+        queryset = WeekPlan.objects.filter(user=user)
+        if _requested_field_names(info) & _DAY_DEPENDENT_FIELDS:
+            queryset = queryset.prefetch_related(
+                Prefetch("days", queryset=_day_queryset())
+            )
         return [
             WeekPlanType.from_model(p)
-            for p in WeekPlan.objects.filter(user=user)
-            .prefetch_related(
-                Prefetch(
-                    "days",
-                    queryset=Day.objects.prefetch_related(
-                        Prefetch(
-                            "intakes",
-                            queryset=Intake.objects.order_by(
-                                "meal_order", "created_at"
-                            ),
-                        )
-                    ).order_by("day"),
-                )
-            )
-            .order_by("-start_date")
+            for p in queryset.order_by("-start_date")
         ]
 
     @strawberry.field
@@ -346,19 +411,12 @@ class PlanQuery:
             return None
 
         try:
-            obj = WeekPlan.objects.prefetch_related(
-                Prefetch(
-                    "days",
-                    queryset=Day.objects.prefetch_related(
-                        Prefetch(
-                            "intakes",
-                            queryset=Intake.objects.order_by(
-                                "meal_order", "created_at"
-                            ),
-                        )
-                    ).order_by("day"),
+            queryset = WeekPlan.objects.filter(pk=id, user=user)
+            if _requested_field_names(info) & _DAY_DEPENDENT_FIELDS:
+                queryset = queryset.prefetch_related(
+                    Prefetch("days", queryset=_day_queryset())
                 )
-            ).get(pk=id, user=user)
+            obj = queryset.get()
         except WeekPlan.DoesNotExist:
             return None
         return WeekPlanType.from_model(obj)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -108,10 +108,11 @@ POSTGRESQL_USER = NUTRITION
 POSTGRESQL_PASSWORD = ENV("POSTGRESQL_PASSWORD", default="")
 POSTGRESQL_HOST = ENV("POSTGRESQL_HOST", default="localhost")
 DB_CONFIG = ENV.db(
+    "DATABASE_URL",
     default=(
         f"postgres://{POSTGRESQL_USER}:{POSTGRESQL_PASSWORD}@"
         f"{POSTGRESQL_HOST}:5432/{POSTGRESQL_DB}"
-    )
+    ),
 )
 
 # Django requires a "default" DB, then

--- a/backend/tests/foods/test_product_schema.py
+++ b/backend/tests/foods/test_product_schema.py
@@ -8,6 +8,8 @@ from decimal import Decimal
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from apps.foods.models import FoodProduct, Serving
 from apps.foods.schema import (
@@ -67,6 +69,31 @@ def _create_user(email: str, *, is_staff: bool = False):
 class TestFoodProductSchema:
     """Tests for FoodProduct mutations and queries."""
 
+    def _count_food_products_with_servings_query(
+        self, mocker, product_count: int
+    ) -> int:
+        """Create products and count SQL queries for nested servings query."""
+        user = _create_user(f"fp-query-{product_count}-count@test.com")
+        mock_context = mocker.Mock()
+        mock_context.request.user = user
+
+        for index in range(product_count):
+            FoodProduct.objects.create(
+                name=f"Product {index}",
+                size=100,
+                size_unit="g",
+                num_servings=1,
+                nutritional_info_size=100,
+                nutritional_info_unit="g",
+            )
+
+        query = "{ foodProducts { id name servings { id energyKcal } } }"
+        with CaptureQueriesContext(connection) as captured:
+            result = schema.execute_sync(query, context_value=mock_context)
+
+        assert result.errors is None
+        return len(captured)
+
     def test_food_products_query(self, mocker):
         """Test listing food products."""
         user = _create_user("fp1@test.com")
@@ -88,6 +115,17 @@ class TestFoodProductSchema:
         # ordered by name
         assert result.data["foodProducts"][0]["name"] == "Apple"
         assert result.data["foodProducts"][1]["name"] == "Banana"
+
+    def test_food_products_query_with_servings_has_bounded_query_growth(
+        self, mocker
+    ):
+        """Nested servings queries stop increasing with more products."""
+        base_queries = self._count_food_products_with_servings_query(mocker, 2)
+        growth_queries = self._count_food_products_with_servings_query(
+            mocker, 10
+        )
+
+        assert growth_queries == base_queries
 
     def test_create_food_product(self, mocker):
         """Test creating a food product."""

--- a/backend/tests/foods/test_recipe_schema.py
+++ b/backend/tests/foods/test_recipe_schema.py
@@ -68,6 +68,72 @@ class TestRecipeQuery:
         assert result.errors is None
         return len(captured)
 
+    def _count_recipes_with_food_label_query(
+        self, mocker, recipe_count: int
+    ) -> int:
+        """Create recipes and count SQL queries for nested food labels."""
+        user = _create_user(f"rq-foodlabel-{recipe_count}-bounded@test.com")
+        mock_context = mocker.Mock()
+        mock_context.request.user = user
+
+        product = FoodProduct.objects.create(
+            name="Ingredient",
+            size=100,
+            size_unit="g",
+            num_servings=1,
+            nutritional_info_size=100,
+            nutritional_info_unit="g",
+        )
+        serving = product.servings.get(serving_size=100, serving_unit="g")
+
+        for index in range(recipe_count):
+            recipe = Recipe.objects.create(
+                name=f"Recipe {index}",
+                size=100,
+                size_unit="g",
+                num_servings=1,
+            )
+            RecipeIngredient.objects.create(
+                recipe=recipe,
+                food=serving,
+                num_servings=1,
+            )
+
+        query = "{ recipes { id name ingredients { id foodLabel } } }"
+        with CaptureQueriesContext(connection) as captured:
+            result = schema.execute_sync(query, context_value=mock_context)
+
+        assert result.errors is None
+        assert (
+            "Ingredient"
+            in result.data["recipes"][0]["ingredients"][0]["foodLabel"]
+        )
+        return len(captured)
+
+    def test_recipes_food_label_query_has_bounded_budget(self, mocker):
+        """Ingredient labels no longer issue one query per ingredient."""
+        small_count = self._count_recipes_with_food_label_query(mocker, 1)
+        large_count = self._count_recipes_with_food_label_query(mocker, 4)
+
+        assert small_count == large_count
+
+    def test_recipes_scalar_only_query_is_lean(self, mocker):
+        """Scalar-only recipe queries skip the ingredients hydration."""
+        user = _create_user("rq-scalar-budget@test.com")
+        mock_context = mocker.Mock()
+        mock_context.request.user = user
+        Recipe.objects.create(
+            name="Solo", size=100, size_unit="g", num_servings=1
+        )
+
+        with CaptureQueriesContext(connection) as captured:
+            result = schema.execute_sync(
+                "{ recipes { id name } }", context_value=mock_context
+            )
+
+        assert result.errors is None
+        assert len(captured) == 1
+
     def test_recipes_query(self, mocker):
         """Test listing recipes."""
         # Given an authenticated user and some recipes

--- a/backend/tests/foods/test_recipe_schema.py
+++ b/backend/tests/foods/test_recipe_schema.py
@@ -7,6 +7,8 @@ from decimal import Decimal
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from apps.foods.models import FoodProduct, Recipe, RecipeIngredient
 from config.schema import schema
@@ -27,6 +29,44 @@ def _create_user(email, *, is_staff=False):
 @pytest.mark.django_db
 class TestRecipeQuery:
     """Tests for recipe queries."""
+
+    def _count_recipes_with_ingredient_query(
+        self, mocker, recipe_count: int
+    ) -> int:
+        """Create recipes and count SQL queries for nested ingredients."""
+        user = _create_user(f"rq-query-{recipe_count}-bounded@test.com")
+        mock_context = mocker.Mock()
+        mock_context.request.user = user
+
+        product = FoodProduct.objects.create(
+            name="Ingredient",
+            size=100,
+            size_unit="g",
+            num_servings=1,
+            nutritional_info_size=100,
+            nutritional_info_unit="g",
+        )
+        serving = product.servings.get(serving_size=100, serving_unit="g")
+
+        for index in range(recipe_count):
+            recipe = Recipe.objects.create(
+                name=f"Recipe {index}",
+                size=100,
+                size_unit="g",
+                num_servings=1,
+            )
+            RecipeIngredient.objects.create(
+                recipe=recipe,
+                food=serving,
+                num_servings=1,
+            )
+
+        query = "{ recipes { id name ingredients { id } } }"
+        with CaptureQueriesContext(connection) as captured:
+            result = schema.execute_sync(query, context_value=mock_context)
+
+        assert result.errors is None
+        return len(captured)
 
     def test_recipes_query(self, mocker):
         """Test listing recipes."""
@@ -52,6 +92,15 @@ class TestRecipeQuery:
         assert len(result.data["recipes"]) == 2
         assert result.data["recipes"][0]["name"] == "Omelette"
         assert result.data["recipes"][1]["name"] == "Smoothie"
+
+    def test_recipes_query_with_ingredients_has_bounded_query_growth(
+        self, mocker
+    ):
+        """Nested ingredient queries stop increasing with more recipes."""
+        base_queries = self._count_recipes_with_ingredient_query(mocker, 2)
+        growth_queries = self._count_recipes_with_ingredient_query(mocker, 10)
+
+        assert growth_queries == base_queries
 
     def test_recipe_detail_query(self, mocker):
         """Test getting a single recipe."""

--- a/backend/tests/foods/test_recipe_schema.py
+++ b/backend/tests/foods/test_recipe_schema.py
@@ -117,6 +117,65 @@ class TestRecipeQuery:
 
         assert small_count == large_count
 
+    def _count_recipes_with_food_label_fragment_query(
+        self, mocker, recipe_count: int
+    ) -> int:
+        """Count SQL queries for fragment-selected food labels."""
+        user = _create_user(f"rq-foodlabel-fragment-{recipe_count}@test.com")
+        mock_context = mocker.Mock()
+        mock_context.request.user = user
+
+        product = FoodProduct.objects.create(
+            name="Fragment Ingredient",
+            size=100,
+            size_unit="g",
+            num_servings=1,
+            nutritional_info_size=100,
+            nutritional_info_unit="g",
+        )
+        serving = product.servings.get(serving_size=100, serving_unit="g")
+
+        for index in range(recipe_count):
+            recipe = Recipe.objects.create(
+                name=f"Recipe {index}",
+                size=100,
+                size_unit="g",
+                num_servings=1,
+            )
+            RecipeIngredient.objects.create(
+                recipe=recipe,
+                food=serving,
+                num_servings=1,
+            )
+
+        query = (
+            "{ recipes { id name ...IngredientFields } } "
+            "fragment IngredientFields on RecipeType "
+            "{ ingredients { id foodLabel } }"
+        )
+        with CaptureQueriesContext(connection) as captured:
+            result = schema.execute_sync(query, context_value=mock_context)
+
+        assert result.errors is None
+        assert (
+            "Fragment Ingredient"
+            in result.data["recipes"][0]["ingredients"][0]["foodLabel"]
+        )
+        return len(captured)
+
+    def test_recipes_food_label_fragment_query_has_bounded_budget(
+        self, mocker
+    ):
+        """Fragment-selected food labels stay bounded too."""
+        small_count = self._count_recipes_with_food_label_fragment_query(
+            mocker, 1
+        )
+        large_count = self._count_recipes_with_food_label_fragment_query(
+            mocker, 4
+        )
+
+        assert small_count == large_count
+
     def test_recipes_scalar_only_query_is_lean(self, mocker):
         """Scalar-only recipe queries skip the ingredients hydration."""
         user = _create_user("rq-scalar-budget@test.com")

--- a/backend/tests/plans/test_schema.py
+++ b/backend/tests/plans/test_schema.py
@@ -19,8 +19,8 @@ from apps.foods.signals.handlers.cupboard import (
     CupboardItemConsumptionTooBigError,
 )
 from apps.measurements.models import Measurement
-from apps.users.models import User
 from apps.plans.models import Day, Intake, WeekPlan
+from apps.users.models import User
 from config.schema import schema
 
 

--- a/backend/tests/plans/test_schema.py
+++ b/backend/tests/plans/test_schema.py
@@ -14,6 +14,7 @@ from django.db.models.query import QuerySet
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
+from apps.exercises.models import DaySteps, Exercise
 from apps.foods.models import CupboardItem, FoodProduct
 from apps.foods.signals.handlers.cupboard import (
     CupboardItemConsumptionTooBigError,
@@ -146,6 +147,82 @@ class TestPlanGraphQLBudget:
         )
 
         assert small_count == large_count
+
+    def test_week_plans_tdee_query_has_bounded_budget(self, mocker):
+        """TDEE resolution adds no query growth per plan or day."""
+        tdee_query = "{ weekPlans { id days { id tdee } } }"
+        small_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-tdee-budget-small@test.com",
+            plan_count=1,
+            query=tdee_query,
+            include_intakes=True,
+        )
+        large_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-tdee-budget-large@test.com",
+            plan_count=4,
+            query=tdee_query,
+            include_intakes=True,
+        )
+
+        assert small_count == large_count
+
+    def test_week_plans_twee_query_has_bounded_budget(self, mocker):
+        """TWEE aggregation is batched instead of summing per-day TDEE."""
+        twee_query = "{ weekPlans { id twee } }"
+        small_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-twee-budget-small@test.com",
+            plan_count=1,
+            query=twee_query,
+            include_intakes=True,
+        )
+        large_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-twee-budget-large@test.com",
+            plan_count=4,
+            query=twee_query,
+            include_intakes=True,
+        )
+
+        assert small_count == large_count
+
+    def test_week_plans_scalar_only_query_is_lean(self, mocker):
+        """Scalar-only week plan queries skip the days hydration."""
+        scalar_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-scalar-budget@test.com",
+            plan_count=4,
+            query="{ weekPlans { id startDate proteinGKg } }",
+            include_intakes=True,
+        )
+
+        assert scalar_count == 1
+
+    def test_week_plan_tdee_and_twee_match_model_values(self, mocker):
+        """Batched tdee/twee resolution matches the model properties."""
+        user, plan = _create_user_and_plan("plan-tdee-values@test.com")
+        day = Day.objects.filter(plan=plan).first()
+        DaySteps.objects.create(day=day, steps=1000)
+        Exercise.objects.create(
+            day=day, type=Exercise.EXERCISE_WALK, kcals=100
+        )
+        mock_context = mocker.Mock()
+        mock_context.request.user = user
+
+        result = schema.execute_sync(
+            "{ weekPlans { id twee days { id tdee } } }",
+            context_value=mock_context,
+        )
+
+        assert result.errors is None
+        week = result.data["weekPlans"][0]
+        assert week["twee"] == float(plan.twee)
+        day_tdee = next(
+            item["tdee"] for item in week["days"] if item["id"] == str(day.id)
+        )
+        assert day_tdee == float(day.tdee)
 
     def test_days_and_intakes_query_has_bounded_budget(self, mocker):
         """Intake nesting no longer adds query growth per day."""

--- a/backend/tests/plans/test_schema.py
+++ b/backend/tests/plans/test_schema.py
@@ -6,10 +6,12 @@
 
 import datetime
 from decimal import Decimal
+from typing import cast
 
 import pytest
-from django.contrib.auth import get_user_model
+from django.db import connection
 from django.db.models.query import QuerySet
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from apps.foods.models import CupboardItem, FoodProduct
@@ -17,10 +19,9 @@ from apps.foods.signals.handlers.cupboard import (
     CupboardItemConsumptionTooBigError,
 )
 from apps.measurements.models import Measurement
+from apps.users.models import User
 from apps.plans.models import Day, Intake, WeekPlan
 from config.schema import schema
-
-User = get_user_model()
 
 
 def _create_user_and_plan(email: str) -> tuple:
@@ -32,11 +33,14 @@ def _create_user_and_plan(email: str) -> tuple:
     Returns:
         tuple: (user, plan) tuple.
     """
-    user = User.objects.create_user(
-        email=email,
-        password="password123",
-        date_of_birth="2000-01-01",
-        height=170.0,
+    user = cast(
+        User,
+        User.objects.create_user(
+            email=email,
+            password="password123",
+            date_of_birth="2000-01-01",
+            height=170.0,
+        ),
     )
     measurement = Measurement.objects.create(
         user=user, body_fat_perc=Decimal("20.0"), weight=Decimal("80.0")
@@ -50,6 +54,56 @@ def _create_user_and_plan(email: str) -> tuple:
         deficit=Decimal("500.0"),
     )
     return user, plan
+
+
+def _count_week_plan_nested_queries(
+    mocker,
+    *,
+    user_email: str,
+    plan_count: int,
+    query: str,
+    include_intakes: bool = False,
+) -> int:
+    """Create many plans and return SQL query count for one GraphQL query."""
+    user = cast(
+        User,
+        User.objects.create_user(
+            email=user_email,
+            password="password123",
+            date_of_birth="2000-01-01",
+            height=170.0,
+        ),
+    )
+    measurement = Measurement.objects.create(
+        user=user,
+        body_fat_perc=Decimal("20.0"),
+        weight=Decimal("80.0"),
+    )
+    for day_offset in range(plan_count):
+        plan = WeekPlan.objects.create(
+            user=user,
+            measurement=measurement,
+            start_date=datetime.date.today()
+            - datetime.timedelta(days=day_offset),
+            protein_g_kg=Decimal("1.8"),
+            fat_perc=Decimal("25.0"),
+            deficit=Decimal("500.0"),
+        )
+        if include_intakes:
+            for day in Day.objects.filter(plan=plan):
+                Intake.objects.create(day=day, meal=Intake.MEAL_LUNCH)
+
+    mock_context = mocker.Mock()
+    mock_context.request.user = user
+
+    with CaptureQueriesContext(connection) as captured:
+        result = schema.execute_sync(
+            query,
+            context_value=mock_context,
+        )
+    if result.errors is not None:
+        raise AssertionError(result.errors[0])
+    return len(captured)
 
 
 @pytest.mark.django_db
@@ -67,6 +121,51 @@ class TestWeekPlanSchema:
 
         assert len(result.data["weekPlans"]) == 1
         assert result.data["weekPlans"][0]["proteinGKg"] == 1.8
+
+
+@pytest.mark.django_db
+class TestPlanGraphQLBudget:
+    """Regression coverage for nested plan queries."""
+
+    def test_week_plans_and_days_query_has_bounded_budget(self, mocker):
+        """Day nesting no longer adds query growth per plan."""
+        base_query = "{ weekPlans { id days { id dayNum } } }"
+        small_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-days-budget-small@test.com",
+            plan_count=1,
+            query=base_query,
+            include_intakes=False,
+        )
+        large_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-days-budget-large@test.com",
+            plan_count=4,
+            query=base_query,
+            include_intakes=False,
+        )
+
+        assert small_count == large_count
+
+    def test_days_and_intakes_query_has_bounded_budget(self, mocker):
+        """Intake nesting no longer adds query growth per day."""
+        nested_query = "{ weekPlans { id days { id intakes { id meal } } } }"
+        small_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-day-intake-budget-small@test.com",
+            plan_count=1,
+            query=nested_query,
+            include_intakes=True,
+        )
+        large_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-day-intake-budget-large@test.com",
+            plan_count=4,
+            query=nested_query,
+            include_intakes=True,
+        )
+
+        assert small_count == large_count
 
     def test_create_week_plan(self, mocker):
         """Test creating a week plan."""
@@ -460,6 +559,98 @@ class TestDaySchema:
 @pytest.mark.django_db
 class TestIntakeSchema:
     """Tests for Intake mutations."""
+
+    @pytest.mark.parametrize("meal", ["", "   ", "brunch", "Lunch", "dinner!"])
+    def test_create_intake_rejects_invalid_meal(self, mocker, meal):
+        """Only supported meal names are accepted for createIntake."""
+        user, plan = _create_user_and_plan(
+            f"intake-invalid-meal-create-{meal.replace(' ', '-') or 'space'}@test.com"
+        )
+        day = Day.objects.filter(plan=plan).first()
+        mock_context = mocker.Mock()
+        mock_context.request.user = user
+        result = schema.execute_sync(
+            """
+                mutation CreateIntake(
+                    $dayId: Int!, $meal: String!, $numServings: Float!
+                ) {
+                    createIntake(
+                        dayId: $dayId, meal: $meal, numServings: $numServings,
+                        energyKcal: 100
+                    ) { id }
+                }
+            """,
+            variable_values={
+                "dayId": day.id,
+                "meal": meal,
+                "numServings": 1,
+            },
+            context_value=mock_context,
+        )
+
+        assert result.errors is not None
+        assert "meal must be one of: breakfast, lunch, snack, dinner" in str(
+            result.errors[0]
+        )
+        assert not Intake.objects.filter(day=day).exists()
+
+    @pytest.mark.parametrize("meal", ["", "   ", "brunch", "Lunch", "snacK"])
+    def test_update_intake_rejects_invalid_meal(self, mocker, meal):
+        """Only supported meal names are accepted for updateIntake."""
+        user, plan = _create_user_and_plan(
+            f"intake-invalid-meal-update-{meal.replace(' ', '-') or 'space'}@test.com"
+        )
+        day = Day.objects.filter(plan=plan).first()
+        intake = Intake.objects.create(
+            day=day,
+            meal="lunch",
+            num_servings=1,
+            energy_kcal=200,
+            protein_g=15,
+        )
+        original_intake_state = (
+            intake.meal,
+            intake.num_servings,
+            intake.energy_kcal,
+            intake.protein_g,
+            intake.fat_g,
+            intake.carbs_g,
+        )
+        mock_context = mocker.Mock()
+        mock_context.request.user = user
+
+        result = schema.execute_sync(
+            """
+                mutation UpdateIntake(
+                    $id: ID!, $meal: String!, $numServings: Float!
+                ) {
+                    updateIntake(
+                        id: $id, meal: $meal, numServings: $numServings,
+                        energyKcal: 300
+                    ) { id }
+                }
+            """,
+            variable_values={
+                "id": str(intake.id),
+                "meal": meal,
+                "numServings": 2,
+            },
+            context_value=mock_context,
+        )
+
+        assert result.errors is not None
+        assert "meal must be one of: breakfast, lunch, snack, dinner" in str(
+            result.errors[0]
+        )
+        intake.refresh_from_db()
+        assert (
+            intake.meal,
+            intake.num_servings,
+            intake.energy_kcal,
+            intake.protein_g,
+            intake.fat_g,
+            intake.carbs_g,
+        ) == original_intake_state
 
     def test_create_intake_custom(self, mocker):
         """Test creating a custom intake with direct macros."""

--- a/backend/tests/plans/test_schema.py
+++ b/backend/tests/plans/test_schema.py
@@ -224,6 +224,51 @@ class TestPlanGraphQLBudget:
         )
         assert day_tdee == float(day.tdee)
 
+    def test_week_plans_fragment_query_has_bounded_budget(self, mocker):
+        """Named fragment day selections keep the hydration bounded."""
+        fragment_query = (
+            "{ weekPlans { id ...WeekPlanFragment } } "
+            "fragment WeekPlanFragment on WeekPlanType { days { id tdee } }"
+        )
+        small_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-fragment-budget-small@test.com",
+            plan_count=1,
+            query=fragment_query,
+            include_intakes=True,
+        )
+        large_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-fragment-budget-large@test.com",
+            plan_count=4,
+            query=fragment_query,
+            include_intakes=True,
+        )
+
+        assert small_count == large_count
+
+    def test_week_plans_inline_fragment_query_has_bounded_budget(self, mocker):
+        """Inline fragment day selections also trigger the hydration."""
+        inline_query = (
+            "{ weekPlans { id ... on WeekPlanType { days { id tdee } } } }"
+        )
+        small_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-inline-fragment-budget-small@test.com",
+            plan_count=1,
+            query=inline_query,
+            include_intakes=True,
+        )
+        large_count = _count_week_plan_nested_queries(
+            mocker,
+            user_email="plan-inline-fragment-budget-large@test.com",
+            plan_count=4,
+            query=inline_query,
+            include_intakes=True,
+        )
+
+        assert small_count == large_count
+
     def test_days_and_intakes_query_has_bounded_budget(self, mocker):
         """Intake nesting no longer adds query growth per day."""
         nested_query = "{ weekPlans { id days { id intakes { id meal } } } }"


### PR DESCRIPTION
Closes #378
Closes #381

## Summary
- Added canonical meal validation in `Intake` (`validate_meal`, `meal_order_for`) and enforced it on create/update intake mutations.
- Added model-level normalization + deterministic meal sorting in `Intake.save()`.
- Refactored plan and food GraphQL resolvers to prefetch related rows and use cached models in type wrappers.
- Added bounded-query regression tests for:
  - `weekPlans -> days -> intakes`
  - `foodProducts -> servings`
  - `recipes -> ingredients`
- Added meal invalidation tests for create/update intake mutations.
- Updated Makefile pytest target to provide test env defaults:
  - `DJANGO_SETTINGS_MODULE=config.settings`
  - `SECRET_KEY`
  - `GEMINI_API_KEY`
  - `DATABASE_URL=sqlite:///db.sqlite3`
- Updated settings DB loading to read `ENV.db("DATABASE_URL", ...)`.

## Verification
- `cd backend && DJANGO_SETTINGS_MODULE=config.settings SECRET_KEY=insecure-local-test-secret GEMINI_API_KEY=local-test-gemini-key DATABASE_URL=sqlite:///db.sqlite3 uv run pytest --no-cov tests/foods/test_product_schema.py tests/foods/test_recipe_schema.py tests/plans/test_schema.py -k "bounded_query or invalid_meal" -x`
  - Result: `12 passed, 439 deselected`
- `cd backend && uv run black --check apps/foods/schema.py apps/plans/models/intake.py apps/plans/schema.py tests/foods/test_product_schema.py tests/foods/test_recipe_schema.py tests/plans/test_schema.py config/settings.py`
  - Result: `7 files would be left unchanged.`
- `cd backend && DJANGO_SETTINGS_MODULE=config.settings SECRET_KEY=insecure-local-test-secret GEMINI_API_KEY=local-test-gemini-key DATABASE_URL=sqlite:///db.sqlite3 uv run mypy apps/plans/schema.py apps/foods/schema.py apps/plans/models/intake.py tests/plans/test_schema.py tests/foods/test_product_schema.py tests/foods/test_recipe_schema.py`
  - Result: `Success: no issues found`
- `cd backend && DJANGO_SETTINGS_MODULE=config.settings SECRET_KEY=insecure-local-test-secret GEMINI_API_KEY=local-test-gemini-key DATABASE_URL=sqlite:///db.sqlite3 uv run pylint --exit-zero apps/plans/models/intake.py apps/plans/schema.py apps/foods/schema.py tests/plans/test_schema.py tests/foods/test_product_schema.py tests/foods/test_recipe_schema.py`
  - Result: runs successfully; pre-existing warning-level findings only (no new errors introduced)

## Notes
- Per repository rule, no real deployment identifier/domain values were added in this diff.
