### PR TITLE
feat(dashboard): prioritize daily nutrition tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,16 @@ This rule is mandatory and has no exceptions.
 
 All contributors, automation, coding agents, and reviewers must enforce this rule.
 
+## Pull-Request Ready Handoff
+
+When reporting that a pull request is ready:
+
+- Do not call it ready until the terminal preview-environment CI job has succeeded.
+- Retrieve and verify the deployed preview URL from the deployment system.
+- Include the pull-request URL, deployed preview URL, and final CI status in the direct handoff to the repository owner so the change can be inspected immediately.
+- Treat the preview URL as sensitive. Share the real value only in the owner's direct handoff; never add it to repository files, commits, pull-request text, review replies, issues, CI logs, screenshots, or public/multi-user channels. If the current channel is not private, ask the owner where to send it.
+- If a preview was not deployed, state that explicitly instead of implying the pull request is ready for visual inspection.
+
 ## Codex Review Trigger
 
 When requesting a Codex review for this repository, post this exact comment:

--- a/backend/config/schema.py
+++ b/backend/config/schema.py
@@ -22,7 +22,9 @@ from apps.foods.schema import (
 )
 from apps.goals.schema import GoalMutation, GoalQuery
 from apps.libs.graphql import get_request_user
+from apps.measurements.models import Measurement
 from apps.measurements.schema import MeasurementMutation, MeasurementQuery
+from apps.plans.models import Day
 from apps.plans.schema import PlanMutation, PlanQuery
 from config.middleware import authenticated_request_user
 
@@ -58,12 +60,35 @@ def authenticated_user(context: Any) -> Any:
 
 
 @strawberry.type
+class DashboardMeasurement:
+    """A bounded measurement point for the dashboard trend."""
+
+    id: strawberry.ID
+    weight: float
+    body_fat_perc: float
+    created_at: str
+
+
+@strawberry.type
+class DashboardNutrition:
+    """The current user's nutrition totals for one local calendar day."""
+
+    id: strawberry.ID
+    day: str
+    energy_kcal: float
+    energy_kcal_goal: float
+    intake_count: int
+
+
+@strawberry.type
 class DashboardData:
     """Dashboard specific data."""
 
     latest_weight: float | None
     latest_body_fat: float | None
     goal_body_fat: float | None
+    recent_measurements: list[DashboardMeasurement]
+    today_nutrition: DashboardNutrition | None
 
 
 @strawberry.type
@@ -77,7 +102,7 @@ class UserType:
     is_staff: bool
 
     @strawberry.field
-    def dashboard(self) -> DashboardData:
+    def dashboard(self, timezone_offset_minutes: int = 0) -> DashboardData:
         """Get dashboard data.
 
         Returns:
@@ -94,8 +119,25 @@ class UserType:
         # Let's use the ID to be safe and clear.
 
         user_model = User.objects.get(pk=self.id)
-        measurement = user_model.measurements.last()  # type: ignore
-        goal = user_model.fat_perc_goals.last()  # type: ignore
+        measurements = list(
+            Measurement.objects.filter(user=user_model).order_by(
+                "-created_at", "-id"
+            )[:14]
+        )
+        measurement = measurements[0] if measurements else None
+        goal = user_model.fat_perc_goals.order_by(  # type: ignore
+            "-created_at", "-id"
+        ).first()
+
+        safe_offset = max(-14 * 60, min(14 * 60, timezone_offset_minutes))
+        local_today = (
+            datetime.now(timezone.utc) - timedelta(minutes=safe_offset)
+        ).date()
+        today = (
+            Day.objects.filter(plan__user=user_model, day=local_today)
+            .order_by("-plan__start_date", "-plan_id")
+            .first()
+        )
 
         return DashboardData(
             latest_weight=float(measurement.weight) if measurement else None,
@@ -103,6 +145,26 @@ class UserType:
                 float(measurement.body_fat_perc) if measurement else None
             ),
             goal_body_fat=float(goal.body_fat_perc) if goal else None,
+            recent_measurements=[
+                DashboardMeasurement(
+                    id=strawberry.ID(str(item.id)),
+                    weight=float(item.weight),
+                    body_fat_perc=float(item.body_fat_perc),
+                    created_at=item.created_at.isoformat(),
+                )
+                for item in reversed(measurements)
+            ],
+            today_nutrition=(
+                DashboardNutrition(
+                    id=strawberry.ID(str(today.id)),
+                    day=today.day.isoformat(),
+                    energy_kcal=float(today.energy_kcal),
+                    energy_kcal_goal=float(today.energy_kcal_goal),
+                    intake_count=today.intakes.count(),
+                )
+                if today
+                else None
+            ),
         )
 
 

--- a/backend/config/schema.py
+++ b/backend/config/schema.py
@@ -105,36 +105,30 @@ class UserType:
     def dashboard(self, timezone_offset_minutes: int = 0) -> DashboardData:
         """Get dashboard data.
 
+        Args:
+            timezone_offset_minutes: Browser offset from UTC in minutes.
+
         Returns:
             DashboardData: Dashboard data object
         """
-        # pylint: disable=no-member
-        # self is the UserType instance or the User model depending on how it
-        # was returned.
-        # But for Mypy, it treats it as UserType.
-        # We need to fetch the actual user model to get relations safely.
-        # Since self.id is available, we can query.
-        # However, at runtime 'self' IS the User model if returned from 'me'.
-        # To satisfy mypy, casting or fresh query is needed.
-        # Let's use the ID to be safe and clear.
-
-        user_model = User.objects.get(pk=self.id)
         measurements = list(
-            Measurement.objects.filter(user=user_model).order_by(
+            Measurement.objects.filter(user_id=self.id).order_by(
                 "-created_at", "-id"
             )[:14]
         )
         measurement = measurements[0] if measurements else None
-        goal = user_model.fat_perc_goals.order_by(  # type: ignore
-            "-created_at", "-id"
-        ).first()
+        goal = (
+            User.objects.get(pk=self.id)
+            .fat_perc_goals.order_by("-created_at", "-id")  # type: ignore
+            .first()
+        )
 
         safe_offset = max(-14 * 60, min(14 * 60, timezone_offset_minutes))
         local_today = (
             datetime.now(timezone.utc) - timedelta(minutes=safe_offset)
         ).date()
         today = (
-            Day.objects.filter(plan__user=user_model, day=local_today)
+            Day.objects.filter(plan__user_id=self.id, day=local_today)
             .order_by("-plan__start_date", "-plan_id")
             .first()
         )

--- a/backend/tests/config/test_schema.py
+++ b/backend/tests/config/test_schema.py
@@ -319,8 +319,8 @@ def test_me_query_rejects_bearer_for_inactive_user():
 
 
 @pytest.mark.django_db
-def test_user_dashboard():
-    """Test dashboard resolver in UserType."""
+def test_user_dashboard(week_plan_factory, intake_factory):
+    """Dashboard returns bounded trend and today's actionable nutrition data."""
     # Given a user with measurements and goals
     user = User.objects.create_user(
         email="dash@example.com",
@@ -331,36 +331,76 @@ def test_user_dashboard():
 
     # When querying for the user's dashboard (without actual data yet)
     query = """
-        query {
+        query Dashboard($timezoneOffsetMinutes: Int!) {
             me {
-                dashboard {
+                dashboard(timezoneOffsetMinutes: $timezoneOffsetMinutes) {
                     latestWeight
                     latestBodyFat
                     goalBodyFat
+                    recentMeasurements {
+                        id
+                        weight
+                        bodyFatPerc
+                        createdAt
+                    }
+                    todayNutrition {
+                        id
+                        day
+                        energyKcal
+                        energyKcalGoal
+                        intakeCount
+                    }
                 }
             }
         }
     """
     # Use an authenticated session context
     mock_context = SimpleNamespace(user=user)
+    variables = {"timezoneOffsetMinutes": 0}
 
-    result = schema.execute_sync(query, context_value=mock_context)
+    result = schema.execute_sync(
+        query, context_value=mock_context, variable_values=variables
+    )
 
     # Then we get null values since no measurements exist
     assert result.data["me"]["dashboard"]["latestWeight"] is None
 
-    # When we add a measurement and a goal
-    Measurement.objects.create(user=user, weight=80.5, body_fat_perc=20.0)
+    # When we add measurements, a goal, and a plan containing today
+    measurement = Measurement.objects.create(
+        user=user, weight=80.5, body_fat_perc=20.0
+    )
+    for index in range(15):
+        Measurement.objects.create(
+            user=user,
+            weight=80.0 - index / 10,
+            body_fat_perc=20.0 - index / 10,
+        )
     FatPercGoal.objects.create(user=user, body_fat_perc=15.0)
+    today = datetime.now(timezone.utc).date()
+    plan = week_plan_factory(
+        user=user,
+        measurement=measurement,
+        start_date=today,
+    )
+    today_day = plan.days.get(day=today)
+    intake_factory(day=today_day)
 
     # And query again
-    result = schema.execute_sync(query, context_value=mock_context)
+    result = schema.execute_sync(
+        query, context_value=mock_context, variable_values=variables
+    )
 
-    # Then we get the real values
+    # Then the response is actionable and history is bounded
+    assert result.errors is None
     dash = result.data["me"]["dashboard"]
-    assert dash["latestWeight"] == 80.5
-    assert dash["latestBodyFat"] == 20.0
+    assert dash["latestWeight"] == 78.6
+    assert dash["latestBodyFat"] == 18.6
     assert dash["goalBodyFat"] == 15.0
+    assert len(dash["recentMeasurements"]) == 14
+    assert dash["recentMeasurements"][-1]["weight"] == 78.6
+    assert dash["todayNutrition"]["id"] == str(today_day.id)
+    assert dash["todayNutrition"]["day"] == today.isoformat()
+    assert dash["todayNutrition"]["intakeCount"] == 1
 
 
 @pytest.mark.django_db

--- a/webapp/src/app/intakes/new/page.tsx
+++ b/webapp/src/app/intakes/new/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 import { graphqlRequest, gql } from '@/lib/graphql'
 import EntityForm from '@/components/EntityForm'
@@ -26,10 +27,12 @@ const MEAL_CHOICES = [
 ]
 
 export default function NewIntakePage() {
-  const [form, setForm] = useState({
-    dayId: '', meal: 'breakfast', numServings: '1.0',
+  const searchParams = useSearchParams()
+  const dayIdFromQuery = searchParams.get('dayId')
+  const [form, setForm] = useState(() => ({
+    dayId: dayIdFromQuery ?? '', meal: 'breakfast', numServings: '1.0',
     energyKcal: '', proteinG: '', fatG: '', carbsG: ''
-  })
+  }))
   const [saving, setSaving] = useState(false)
 
   const handleChange = (name: string, value: string) => { setForm(prev => ({ ...prev, [name]: value })) }

--- a/webapp/src/components/Dashboard.tsx
+++ b/webapp/src/components/Dashboard.tsx
@@ -270,7 +270,7 @@ function WeightTrend({ series }: { series: ReturnType<typeof buildWeightTrendSer
           </circle>
         ))}
       </svg>
-      <div className="flex justify-between text-xs text-slate-500">
+      <div className="flex justify-between text-xs text-slate-400">
         <span>{first.date}</span><span>{last.date}</span>
       </div>
     </div>

--- a/webapp/src/components/Dashboard.tsx
+++ b/webapp/src/components/Dashboard.tsx
@@ -9,6 +9,8 @@ import { gql, graphqlRequest } from '@/lib/graphql'
 import {
   buildTrendCoordinates,
   buildWeightTrendSeries,
+  describeWeightTrendChange,
+  millisecondsUntilNextLocalDay,
   type DashboardMeasurement,
 } from './dashboardHelpers'
 
@@ -70,6 +72,7 @@ export default function Dashboard() {
   useEffect(() => {
     if (status !== 'authenticated') return
     let cancelled = false
+    let midnightTimer: ReturnType<typeof setTimeout> | undefined
 
     async function loadDashboard() {
       setLoading(true)
@@ -91,8 +94,28 @@ export default function Dashboard() {
       }
     }
 
+    function scheduleMidnightRefresh() {
+      midnightTimer = setTimeout(async () => {
+        await loadDashboard()
+        if (!cancelled) scheduleMidnightRefresh()
+      }, millisecondsUntilNextLocalDay())
+    }
+
+    function refreshWhenVisible() {
+      if (!document.hidden) void loadDashboard()
+    }
+
     void loadDashboard()
-    return () => { cancelled = true }
+    scheduleMidnightRefresh()
+    window.addEventListener('focus', refreshWhenVisible)
+    document.addEventListener('visibilitychange', refreshWhenVisible)
+
+    return () => {
+      cancelled = true
+      if (midnightTimer) clearTimeout(midnightTimer)
+      window.removeEventListener('focus', refreshWhenVisible)
+      document.removeEventListener('visibilitychange', refreshWhenVisible)
+    }
   }, [status])
 
   const summary = response?.me?.dashboard
@@ -234,7 +257,7 @@ function WeightTrend({ series }: { series: ReturnType<typeof buildWeightTrendSer
   const first = series[0]
   const last = series.at(-1)!
   const change = last.weight - first.weight
-  const label = `Weight trend from ${first.weight} kilograms to ${last.weight} kilograms, ${change >= 0 ? 'up' : 'down'} ${Math.abs(change).toFixed(1)} kilograms`
+  const label = `Weight trend from ${first.weight} kilograms to ${last.weight} kilograms, ${describeWeightTrendChange(change)}`
 
   return (
     <div>

--- a/webapp/src/components/Dashboard.tsx
+++ b/webapp/src/components/Dashboard.tsx
@@ -4,12 +4,13 @@ import { motion } from 'framer-motion'
 import { Activity, ArrowRight, Target, UtensilsCrossed, Weight } from 'lucide-react'
 import { signOut, useSession } from 'next-auth/react'
 import Link from 'next/link'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { gql, graphqlRequest } from '@/lib/graphql'
 import {
   buildTrendCoordinates,
   buildWeightTrendSeries,
   describeWeightTrendChange,
+  isCurrentLocalDate,
   millisecondsUntilNextLocalDay,
   type DashboardMeasurement,
 } from './dashboardHelpers'
@@ -68,6 +69,7 @@ export default function Dashboard() {
   const [response, setResponse] = useState<DashboardResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
+  const requestSequence = useRef(0)
 
   useEffect(() => {
     if (status !== 'authenticated') return
@@ -75,22 +77,23 @@ export default function Dashboard() {
     let midnightTimer: ReturnType<typeof setTimeout> | undefined
 
     async function loadDashboard() {
+      const requestId = ++requestSequence.current
       setLoading(true)
       setError(false)
       try {
         const result = await graphqlRequest<DashboardResponse>(DASHBOARD_QUERY, {
           timezoneOffsetMinutes: new Date().getTimezoneOffset(),
         })
-        if (!result.me) {
+        if (!result.me && requestId === requestSequence.current) {
           await signOut({ callbackUrl: '/login' })
           return
         }
-        if (!cancelled) setResponse(result)
+        if (!cancelled && requestId === requestSequence.current) setResponse(result)
       } catch (loadError) {
         console.error('Failed to fetch dashboard data', loadError)
-        if (!cancelled) setError(true)
+        if (!cancelled && requestId === requestSequence.current) setError(true)
       } finally {
-        if (!cancelled) setLoading(false)
+        if (!cancelled && requestId === requestSequence.current) setLoading(false)
       }
     }
 
@@ -112,6 +115,7 @@ export default function Dashboard() {
 
     return () => {
       cancelled = true
+      requestSequence.current += 1
       if (midnightTimer) clearTimeout(midnightTimer)
       window.removeEventListener('focus', refreshWhenVisible)
       document.removeEventListener('visibilitychange', refreshWhenVisible)
@@ -123,10 +127,11 @@ export default function Dashboard() {
   const trend = useMemo(() => buildWeightTrendSeries(measurements), [measurements])
   const latestMeasurement = measurements.at(-1)
   const today = summary?.todayNutrition ?? null
+  const todayIsCurrent = today !== null && isCurrentLocalDate(today.day)
   const currentWeight = latestMeasurement?.weight ?? summary?.latestWeight ?? null
   const currentBodyFat = latestMeasurement?.bodyFatPerc ?? summary?.latestBodyFat ?? null
   const firstName = response?.me?.firstName || session?.user?.name?.split(' ')[0] || 'Athlete'
-  const mealHref = today ? `/intakes/new?dayId=${encodeURIComponent(today.id)}` : '/days'
+  const mealHref = !loading && todayIsCurrent ? `/intakes/new?dayId=${encodeURIComponent(today.id)}` : '/days'
 
   return (
     <div className="min-h-screen p-6 text-white md:p-12">
@@ -157,7 +162,7 @@ export default function Dashboard() {
           href={mealHref}
           icon={<UtensilsCrossed size={24} />}
           title="Log a meal"
-          description={today ? 'Add food directly to today.' : 'Choose a day, then add your meal.'}
+          description={!loading && todayIsCurrent ? 'Add food directly to today.' : 'Choose a day, then add your meal.'}
           accent="emerald"
         />
       </section>
@@ -294,7 +299,7 @@ function CardHeader({ title, icon, color }: { title: string; icon: React.ReactNo
 }
 
 function Metric({ label, value, suffix, highlight = false }: { label: string; value: number | null; suffix: string; highlight?: boolean }) {
-  return <div><p className="text-xs font-bold uppercase tracking-wider text-slate-500">{label}</p><div className="flex items-end gap-1"><span className={`text-4xl font-black ${highlight ? 'text-emerald-400' : 'text-white'}`}>{value ?? 'Not set'}</span>{value !== null && <span className="mb-1 text-sm text-slate-400">{suffix}</span>}</div></div>
+  return <div><p className="text-xs font-bold uppercase tracking-wider text-slate-400">{label}</p><div className="flex items-end gap-1"><span className={`text-4xl font-black ${highlight ? 'text-emerald-400' : 'text-white'}`}>{value ?? 'Not set'}</span>{value !== null && <span className="mb-1 text-sm text-slate-400">{suffix}</span>}</div></div>
 }
 
 function LoadingValue() {

--- a/webapp/src/components/Dashboard.tsx
+++ b/webapp/src/components/Dashboard.tsx
@@ -1,186 +1,287 @@
-"use client";
+'use client'
 
-import { motion } from "framer-motion";
-import { Activity, Droplets, Target } from "lucide-react";
-import { signOut, useSession } from "next-auth/react";
-import { useEffect, useState } from "react";
-import { request, gql } from "graphql-request";
+import { motion } from 'framer-motion'
+import { Activity, ArrowRight, Target, UtensilsCrossed, Weight } from 'lucide-react'
+import { signOut, useSession } from 'next-auth/react'
+import Link from 'next/link'
+import { useEffect, useMemo, useState } from 'react'
+import { gql, graphqlRequest } from '@/lib/graphql'
+import {
+  buildTrendCoordinates,
+  buildWeightTrendSeries,
+  type DashboardMeasurement,
+} from './dashboardHelpers'
 
 const DASHBOARD_QUERY = gql`
-  query GetDashboard {
+  query GetDashboard($timezoneOffsetMinutes: Int!) {
     me {
       firstName
-      dashboard {
+      dashboard(timezoneOffsetMinutes: $timezoneOffsetMinutes) {
         latestWeight
         latestBodyFat
         goalBodyFat
+        recentMeasurements {
+          id
+          createdAt
+          weight
+          bodyFatPerc
+        }
+        todayNutrition {
+          id
+          day
+          energyKcal
+          energyKcalGoal
+          intakeCount
+        }
       }
     }
   }
-`;
+`
 
-interface DashboardData {
-    latestWeight: number | null;
-    latestBodyFat: number | null;
-    goalBodyFat: number | null;
+interface TodayNutrition {
+  id: string
+  day: string
+  energyKcal: number
+  energyKcalGoal: number
+  intakeCount: number
+}
+
+interface DashboardSummary {
+  latestWeight: number | null
+  latestBodyFat: number | null
+  goalBodyFat: number | null
+  recentMeasurements: DashboardMeasurement[]
+  todayNutrition: TodayNutrition | null
 }
 
 interface DashboardResponse {
-    me: {
-        firstName: string;
-        dashboard: DashboardData | null;
-    } | null;
+  me: {
+    firstName: string
+    dashboard: DashboardSummary
+  } | null
 }
 
 export default function Dashboard() {
-    const { data: session } = useSession();
-    const [data, setData] = useState<DashboardData | null>(null);
-    const [fetchedName, setFetchedName] = useState<string | null>(null);
-    const [loading, setLoading] = useState(false);
+  const { data: session, status } = useSession()
+  const [response, setResponse] = useState<DashboardResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
 
-    useEffect(() => {
-        if (!session?.accessToken) return;
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    let cancelled = false
 
-        let cancelled = false;
-        setLoading(true);
+    async function loadDashboard() {
+      setLoading(true)
+      setError(false)
+      try {
+        const result = await graphqlRequest<DashboardResponse>(DASHBOARD_QUERY, {
+          timezoneOffsetMinutes: new Date().getTimezoneOffset(),
+        })
+        if (!result.me) {
+          await signOut({ callbackUrl: '/login' })
+          return
+        }
+        if (!cancelled) setResponse(result)
+      } catch (loadError) {
+        console.error('Failed to fetch dashboard data', loadError)
+        if (!cancelled) setError(true)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
 
-        const loadDashboard = async () => {
-            try {
-                const response = await request<DashboardResponse>(
-                    "/api/graphql",
-                    DASHBOARD_QUERY,
-                    {},
-                    { Authorization: `Bearer ${session.accessToken}` },
-                );
+    void loadDashboard()
+    return () => { cancelled = true }
+  }, [status])
 
-                if (!response.me) {
-                    await signOut({ callbackUrl: "/login" });
-                    return;
-                }
+  const summary = response?.me?.dashboard
+  const measurements = summary?.recentMeasurements ?? []
+  const trend = useMemo(() => buildWeightTrendSeries(measurements), [measurements])
+  const latestMeasurement = measurements.at(-1)
+  const today = summary?.todayNutrition ?? null
+  const currentWeight = latestMeasurement?.weight ?? summary?.latestWeight ?? null
+  const currentBodyFat = latestMeasurement?.bodyFatPerc ?? summary?.latestBodyFat ?? null
+  const firstName = response?.me?.firstName || session?.user?.name?.split(' ')[0] || 'Athlete'
+  const mealHref = today ? `/intakes/new?dayId=${encodeURIComponent(today.id)}` : '/days'
 
-                if (!cancelled && response.me.dashboard) {
-                    setData(response.me.dashboard);
-                }
-                if (!cancelled && response.me.firstName) {
-                    setFetchedName(response.me.firstName);
-                }
-            } catch (error) {
-                console.error("Failed to fetch dashboard data", error);
-            } finally {
-                if (!cancelled) setLoading(false);
-            }
-        };
+  return (
+    <div className="min-h-screen p-6 text-white md:p-12">
+      <motion.header
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className="mb-10"
+      >
+        <p className="mb-2 text-sm font-bold uppercase tracking-[0.22em] text-purple-400">Daily dashboard</p>
+        <h1 data-testid="dashboard-greeting" className="mb-3 text-4xl font-black tracking-tight md:text-6xl">
+          {`Time to dominate, ${firstName}!`}
+        </h1>
+        <p className="max-w-2xl text-lg text-slate-400">
+          Log what matters today and keep your progress moving.
+        </p>
+      </motion.header>
 
-        void loadDashboard();
-        return () => {
-            cancelled = true;
-        };
-    }, [session]);
+      <section aria-label="Quick actions" className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <QuickAction
+          href="/measurements/new"
+          icon={<Weight size={24} />}
+          title="Log today weight"
+          description="Add your daily weight and body-fat measurement."
+          accent="purple"
+        />
+        <QuickAction
+          href={mealHref}
+          icon={<UtensilsCrossed size={24} />}
+          title="Log a meal"
+          description={today ? 'Add food directly to today.' : 'Choose a day, then add your meal.'}
+          accent="emerald"
+        />
+      </section>
 
-    const firstName = fetchedName || session?.user?.name?.split(" ")[0] || "Athlete";
-
-    return (
-        <div className="min-h-screen p-6 md:p-12 text-white">
-            {/* Header */}
-            <motion.div
-                initial={{ opacity: 0, y: -20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6 }}
-                className="mb-12"
-            >
-                <h1 data-testid="dashboard-greeting" className="text-4xl md:text-6xl font-black tracking-tight mb-2">
-                    {`Time to dominate, ${firstName}!`}
-                </h1>
-                <p className="text-slate-400 text-lg">
-                    Review your latest measurements and goals.
-                </p>
-            </motion.div>
-
-            {/* Grid */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-
-                {/* Weight Card */}
-                <Card delay={0.1}>
-                    <div className="flex items-center justify-between mb-4">
-                        <h3 className="text-xl font-bold text-slate-200">Current Weight</h3>
-                        <div className="p-2 bg-purple-500/20 rounded-full text-purple-400">
-                            <Activity size={24} />
-                        </div>
-                    </div>
-                    <div className="flex items-end gap-2">
-                        <span className="text-5xl font-black">{data?.latestWeight ?? "--"}</span>
-                        <span className="text-slate-400 text-xl font-medium mb-1">kg</span>
-                    </div>
-                </Card>
-
-                {/* Body Fat Goal Card */}
-                <Card delay={0.2}>
-                    <div className="flex items-center justify-between mb-4">
-                        <h3 className="text-xl font-bold text-slate-200">Body Composition</h3>
-                        <div className="p-2 bg-emerald-500/20 rounded-full text-emerald-400">
-                            <Target size={24} />
-                        </div>
-                    </div>
-                    <div className="flex items-end gap-4">
-                        <div>
-                            <p className="text-xs text-slate-500 uppercase font-bold tracking-wider">Current</p>
-                            <div className="flex items-end gap-1">
-                                <span className="text-4xl font-black text-white">{data?.latestBodyFat ?? "--"}</span>
-                                <span className="text-slate-400 text-sm mb-1">%</span>
-                            </div>
-                        </div>
-                        <div className="h-8 w-[1px] bg-slate-700 mb-1"></div>
-                        <div>
-                            <p className="text-xs text-slate-500 uppercase font-bold tracking-wider">Goal</p>
-                            <div className="flex items-end gap-1">
-                                <span className="text-4xl font-black text-emerald-400">{data?.goalBodyFat ?? "--"}</span>
-                                <span className="text-emerald-500/50 text-sm mb-1">%</span>
-                            </div>
-                        </div>
-                    </div>
-                </Card>
-
-                {/* Placeholder: Hydration / Streak */}
-                <Card delay={0.3}>
-                    <div className="flex items-center justify-between mb-4">
-                        <h3 className="text-xl font-bold text-slate-200">Hydration</h3>
-                        <div className="p-2 bg-blue-500/20 rounded-full text-blue-400">
-                            <Droplets size={24} />
-                        </div>
-                    </div>
-                    <div className="text-center py-6">
-                        <div className="text-4xl font-black text-blue-400 mb-2">--</div>
-                        <p className="text-slate-400">Data unavailable</p>
-                    </div>
-                </Card>
-
-            </div>
-
-            {/* Measurement logging status */}
-            <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ delay: 0.5, duration: 0.8 }}
-                className="mt-12 p-6 glass-card rounded-2xl"
-            >
-                <h4 className="font-bold text-lg">Measurement logging</h4>
-                <p className="text-slate-400">
-                    Logging new measurements from the dashboard is not available yet.
-                </p>
-            </motion.div>
+      {error && (
+        <div role="alert" className="mb-8 rounded-2xl border border-red-400/30 bg-red-500/10 p-4 text-red-200">
+          Dashboard data could not be loaded. Please refresh and try again.
         </div>
-    );
+      )}
+
+      <section aria-label="Today at a glance" className="grid grid-cols-1 gap-6 md:grid-cols-3">
+        <Card delay={0.1}>
+          <CardHeader title="Current Weight" icon={<Activity size={24} />} color="purple" />
+          {loading ? <LoadingValue /> : currentWeight === null ? (
+            <EmptyValue message="No weight logged yet" href="/measurements/new" linkText="Add your first measurement" />
+          ) : (
+            <div className="flex items-end gap-2">
+              <span className="text-5xl font-black">{currentWeight}</span>
+              <span className="mb-1 text-xl font-medium text-slate-400">kg</span>
+            </div>
+          )}
+        </Card>
+
+        <Card delay={0.2}>
+          <CardHeader title="Body Composition" icon={<Target size={24} />} color="emerald" />
+          {loading ? <LoadingValue /> : currentBodyFat === null && summary?.goalBodyFat === null ? (
+            <EmptyValue message="No body composition data yet" href="/measurements/new" linkText="Add a measurement" />
+          ) : (
+            <div className="flex items-end gap-5">
+              <Metric label="Current" value={currentBodyFat} suffix="%" />
+              <div className="mb-1 h-9 w-px bg-slate-700" />
+              <Metric label="Goal" value={summary?.goalBodyFat ?? null} suffix="%" highlight />
+            </div>
+          )}
+        </Card>
+
+        <Card delay={0.3}>
+          <CardHeader title="Today's Nutrition" icon={<UtensilsCrossed size={24} />} color="blue" />
+          {loading ? <LoadingValue /> : today ? (
+            <div>
+              <div className="mb-2 flex items-end gap-2">
+                <span className="text-4xl font-black">{Math.round(today.energyKcal)}</span>
+                <span className="mb-1 text-sm text-slate-400">/ {Math.round(today.energyKcalGoal)} kcal</span>
+              </div>
+              <div className="mb-3 h-2 overflow-hidden rounded-full bg-slate-800">
+                <div
+                  role="progressbar"
+                  aria-label="Calories logged today"
+                  aria-valuemin={0}
+                  aria-valuemax={Math.max(1, Math.round(today.energyKcalGoal))}
+                  aria-valuenow={Math.min(
+                    Math.round(today.energyKcal),
+                    Math.max(1, Math.round(today.energyKcalGoal)),
+                  )}
+                  aria-valuetext={`${Math.round(today.energyKcal)} of ${Math.round(today.energyKcalGoal)} kilocalories`}
+                  className="h-full rounded-full bg-blue-400"
+                  style={{ width: `${Math.min(100, today.energyKcalGoal > 0 ? (today.energyKcal / today.energyKcalGoal) * 100 : 0)}%` }}
+                />
+              </div>
+              <p className="text-sm text-slate-400">{today.intakeCount} entries logged today</p>
+            </div>
+          ) : (
+            <EmptyValue message="No plan day found for today" href="/days" linkText="Choose a day" />
+          )}
+        </Card>
+      </section>
+
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.35, duration: 0.5 }}
+        className="glass-card mt-8 rounded-3xl p-6"
+        aria-labelledby="weight-trend-title"
+      >
+        <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 id="weight-trend-title" className="text-xl font-bold">Recent weight trend</h2>
+            <p className="text-sm text-slate-400">Your last {trend.length || 0} measurements</p>
+          </div>
+          <Link href="/measurements" className="flex items-center gap-2 text-sm font-bold text-purple-300 hover:text-purple-200">
+            View all <ArrowRight size={16} />
+          </Link>
+        </div>
+        {loading ? <div className="h-40 animate-pulse rounded-2xl bg-white/5" /> : (
+          <WeightTrend series={trend} />
+        )}
+      </motion.section>
+    </div>
+  )
+}
+
+function WeightTrend({ series }: { series: ReturnType<typeof buildWeightTrendSeries> }) {
+  if (series.length < 2) {
+    return <EmptyValue message="Log at least two measurements to see your trend" href="/measurements/new" linkText="Log weight" />
+  }
+  const plot = buildTrendCoordinates(series, { width: 720, height: 180, padding: 20 })
+  const first = series[0]
+  const last = series.at(-1)!
+  const change = last.weight - first.weight
+  const label = `Weight trend from ${first.weight} kilograms to ${last.weight} kilograms, ${change >= 0 ? 'up' : 'down'} ${Math.abs(change).toFixed(1)} kilograms`
+
+  return (
+    <div>
+      <svg role="img" aria-label={label} viewBox={plot.viewBox} className="h-44 w-full" preserveAspectRatio="none">
+        <title>{label}</title>
+        <path d={plot.path} fill="none" stroke="rgb(192 132 252)" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round" vectorEffect="non-scaling-stroke" />
+        {plot.points.map((point) => (
+          <circle key={point.id} cx={point.x} cy={point.y} r="5" fill="rgb(216 180 254)">
+            <title>{`${point.date}: ${point.weight} kg`}</title>
+          </circle>
+        ))}
+      </svg>
+      <div className="flex justify-between text-xs text-slate-500">
+        <span>{first.date}</span><span>{last.date}</span>
+      </div>
+    </div>
+  )
+}
+
+function QuickAction({ href, icon, title, description, accent }: { href: string; icon: React.ReactNode; title: string; description: string; accent: 'purple' | 'emerald' }) {
+  const colors = accent === 'purple' ? 'border-purple-400/20 bg-purple-500/10 text-purple-300' : 'border-emerald-400/20 bg-emerald-500/10 text-emerald-300'
+  return (
+    <Link href={href} className={`group flex items-center gap-4 rounded-2xl border p-5 transition hover:-translate-y-0.5 hover:bg-white/10 ${colors}`}>
+      <div className="rounded-xl bg-black/20 p-3">{icon}</div>
+      <div className="flex-1"><h2 className="font-bold text-white">{title}</h2><p className="text-sm text-slate-400">{description}</p></div>
+      <ArrowRight className="transition-transform group-hover:translate-x-1" size={20} />
+    </Link>
+  )
+}
+
+function CardHeader({ title, icon, color }: { title: string; icon: React.ReactNode; color: 'purple' | 'emerald' | 'blue' }) {
+  const colors = { purple: 'bg-purple-500/20 text-purple-400', emerald: 'bg-emerald-500/20 text-emerald-400', blue: 'bg-blue-500/20 text-blue-400' }
+  return <div className="mb-4 flex items-center justify-between"><h3 className="text-xl font-bold text-slate-200">{title}</h3><div className={`rounded-full p-2 ${colors[color]}`}>{icon}</div></div>
+}
+
+function Metric({ label, value, suffix, highlight = false }: { label: string; value: number | null; suffix: string; highlight?: boolean }) {
+  return <div><p className="text-xs font-bold uppercase tracking-wider text-slate-500">{label}</p><div className="flex items-end gap-1"><span className={`text-4xl font-black ${highlight ? 'text-emerald-400' : 'text-white'}`}>{value ?? 'Not set'}</span>{value !== null && <span className="mb-1 text-sm text-slate-400">{suffix}</span>}</div></div>
+}
+
+function LoadingValue() {
+  return <div aria-label="Loading dashboard value" className="h-12 w-36 animate-pulse rounded-xl bg-white/5" />
+}
+
+function EmptyValue({ message, href, linkText }: { message: string; href: string; linkText: string }) {
+  return <div className="py-3"><p className="mb-2 text-slate-400">{message}</p><Link href={href} className="text-sm font-bold text-purple-300 hover:text-purple-200">{linkText} →</Link></div>
 }
 
 function Card({ children, delay }: { children: React.ReactNode; delay: number }) {
-    return (
-        <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay, duration: 0.5, ease: "easeOut" }}
-            className="glass-card p-6 rounded-3xl hover:bg-white/5 transition-colors"
-        >
-            {children}
-        </motion.div>
-    );
+  return <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay, duration: 0.5, ease: 'easeOut' }} className="glass-card rounded-3xl p-6 transition-colors hover:bg-white/5">{children}</motion.div>
 }

--- a/webapp/src/components/Dashboard.tsx
+++ b/webapp/src/components/Dashboard.tsx
@@ -201,7 +201,7 @@ export default function Dashboard() {
 
         <Card delay={0.3}>
           <CardHeader title="Today's Nutrition" icon={<UtensilsCrossed size={24} />} color="blue" />
-          {loading ? <LoadingValue /> : today ? (
+          {loading ? <LoadingValue /> : today && todayIsCurrent ? (
             <div>
               <div className="mb-2 flex items-end gap-2">
                 <span className="text-4xl font-black">{Math.round(today.energyKcal)}</span>

--- a/webapp/src/components/dashboardHelpers.ts
+++ b/webapp/src/components/dashboardHelpers.ts
@@ -11,6 +11,18 @@ export interface WeightTrendPoint {
   weight: number
 }
 
+export function millisecondsUntilNextLocalDay(now = new Date()): number {
+  const nextDay = new Date(now)
+  nextDay.setHours(24, 0, 0, 0)
+  return Math.max(1, nextDay.getTime() - now.getTime())
+}
+
+export function describeWeightTrendChange(change: number): string {
+  if (change === 0) return 'unchanged'
+  const direction = change > 0 ? 'up' : 'down'
+  return `${direction} ${Math.abs(change).toFixed(1)} kilograms`
+}
+
 export function normalizeDateForComparison(
   value: string,
   timezoneOffsetMinutes?: number,

--- a/webapp/src/components/dashboardHelpers.ts
+++ b/webapp/src/components/dashboardHelpers.ts
@@ -34,6 +34,10 @@ export function normalizeDateForComparison(
   return new Date(date.getTime() - offset * 60_000).toISOString().slice(0, 10)
 }
 
+export function isCurrentLocalDate(value: string, now = new Date()): boolean {
+  return value === normalizeDateForComparison(now.toISOString(), now.getTimezoneOffset())
+}
+
 export function buildWeightTrendSeries(
   measurements: DashboardMeasurement[],
   limit = 14,

--- a/webapp/src/components/dashboardHelpers.ts
+++ b/webapp/src/components/dashboardHelpers.ts
@@ -1,0 +1,68 @@
+export interface DashboardMeasurement {
+  id: string
+  createdAt: string
+  weight: number
+  bodyFatPerc: number
+}
+
+export interface WeightTrendPoint {
+  id: string
+  date: string
+  weight: number
+}
+
+export function normalizeDateForComparison(
+  value: string,
+  timezoneOffsetMinutes?: number,
+): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return value.slice(0, 10)
+  const offset = timezoneOffsetMinutes ?? date.getTimezoneOffset()
+  return new Date(date.getTime() - offset * 60_000).toISOString().slice(0, 10)
+}
+
+export function buildWeightTrendSeries(
+  measurements: DashboardMeasurement[],
+  limit = 14,
+): WeightTrendPoint[] {
+  return [...measurements]
+    .filter((measurement) => Number.isFinite(measurement.weight))
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+    .slice(-limit)
+    .map((measurement) => ({
+      id: measurement.id,
+      date: normalizeDateForComparison(measurement.createdAt),
+      weight: measurement.weight,
+    }))
+}
+
+export function buildTrendCoordinates(
+  series: WeightTrendPoint[],
+  dimensions: { width: number; height: number; padding: number },
+) {
+  const { width, height, padding } = dimensions
+  const weights = series.map((point) => point.weight)
+  const min = Math.min(...weights)
+  const max = Math.max(...weights)
+  const range = max - min
+  const availableWidth = width - padding * 2
+  const availableHeight = height - padding * 2
+
+  const points = series.map((point, index) => ({
+    ...point,
+    x:
+      series.length === 1
+        ? width / 2
+        : padding + (index / (series.length - 1)) * availableWidth,
+    y:
+      range === 0
+        ? height / 2
+        : padding + ((max - point.weight) / range) * availableHeight,
+  }))
+  const path = points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`)
+    .join(' ')
+
+  return { points, path, viewBox: `0 0 ${width} ${height}` }
+}

--- a/webapp/tests/dashboard-overhaul.test.mjs
+++ b/webapp/tests/dashboard-overhaul.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import {
+  buildTrendCoordinates,
+  buildWeightTrendSeries,
+  normalizeDateForComparison,
+} from '../src/components/dashboardHelpers.ts'
+
+test('trend helpers sort weights by date and trim to recent points', () => {
+  const measurements = [
+    { id: '1', createdAt: '2026-02-01T10:00:00Z', weight: 80, bodyFatPerc: 21 },
+    { id: '2', createdAt: '2026-02-03T10:00:00Z', weight: 79.2, bodyFatPerc: 20.6 },
+    { id: '3', createdAt: '2026-01-30T10:00:00Z', weight: 81, bodyFatPerc: 21.3 },
+    { id: '4', createdAt: '2026-02-02T10:00:00Z', weight: 79.8, bodyFatPerc: 20.9 },
+  ]
+
+  const trend = buildWeightTrendSeries(measurements, 3)
+
+  assert.deepEqual(trend.map((entry) => entry.weight), [80, 79.8, 79.2])
+  assert.deepEqual(
+    trend.map((entry) => entry.date),
+    ['2026-02-01', '2026-02-02', '2026-02-03'],
+  )
+})
+
+test('trend coordinate mapping is bounded and stable for flat series', () => {
+  const trendPoints = buildWeightTrendSeries([
+    { id: '1', createdAt: '2026-02-01T00:00:00Z', weight: 70, bodyFatPerc: 21 },
+    { id: '2', createdAt: '2026-02-02T00:00:00Z', weight: 70, bodyFatPerc: 20.5 },
+    { id: '3', createdAt: '2026-02-03T00:00:00Z', weight: 70, bodyFatPerc: 20 },
+  ], 3)
+
+  const plot = buildTrendCoordinates(trendPoints, {
+    width: 320,
+    height: 120,
+    padding: 20,
+  })
+
+  assert.equal(plot.points.length, 3)
+  assert.equal(plot.points[0].x, 20)
+  assert.equal(plot.points[2].x, 300)
+  assert.equal(plot.points[0].y, plot.points[2].y)
+  assert.equal(plot.path.startsWith('M 20 '), true)
+  assert.equal(typeof plot.viewBox, 'string')
+})
+
+test('measurement dates use the local calendar date across midnight offsets', () => {
+  assert.equal(
+    normalizeDateForComparison('2026-02-03T00:30:00Z', 120),
+    '2026-02-02',
+  )
+  assert.equal(
+    normalizeDateForComparison('2026-02-03T23:30:00Z', -120),
+    '2026-02-04',
+  )
+  assert.equal(normalizeDateForComparison('2026-02-03'), '2026-02-03')
+})
+
+test('dashboard query and actions include required data shape and remove hydration placeholder', async () => {
+  const dashboardSource = await readFile(
+    new URL('../src/components/Dashboard.tsx', import.meta.url),
+    'utf8',
+  )
+
+  assert.match(dashboardSource, /DASHBOARD_QUERY/)
+  assert.match(dashboardSource, /latestWeight/)
+  assert.match(dashboardSource, /latestBodyFat/)
+  assert.match(dashboardSource, /goalBodyFat/)
+  assert.match(dashboardSource, /dashboard\(timezoneOffsetMinutes:/)
+  assert.match(dashboardSource, /recentMeasurements\s*\{/)
+  assert.match(dashboardSource, /todayNutrition\s*\{/)
+  assert.match(dashboardSource, /intakeCount/)
+  assert.doesNotMatch(dashboardSource, /^\s*measurements\s*\{/m)
+  assert.doesNotMatch(dashboardSource, /weekPlans\s*\{/)
+  assert.match(dashboardSource, /Log today weight/i)
+  assert.match(dashboardSource, /Log a meal/i)
+  assert.match(dashboardSource, /role="progressbar"/)
+  assert.match(dashboardSource, /aria-valuetext=/)
+  assert.match(dashboardSource, /key=\{point\.id\}/)
+  assert.doesNotMatch(dashboardSource, /Hydration/)
+  assert.doesNotMatch(dashboardSource, /Measurement logging.*unavailable/i)
+})
+
+test('intake form source reads dayId from query parameters', async () => {
+  const intakeSource = await readFile(
+    new URL('../src/app/intakes/new/page.tsx', import.meta.url),
+    'utf8',
+  )
+
+  assert.match(intakeSource, /useSearchParams/)
+  assert.match(intakeSource, /dayIdFromQuery = searchParams\.get\('dayId'\)/)
+  assert.match(intakeSource, /const \[form, setForm\] = useState\(\(\) => \(\{[^}]*dayId:/s)
+
+  const { buildCustomIntakeVariables } = await import(
+    '../src/app/intakes/new/intakeVariables.ts'
+  )
+  assert.equal(buildCustomIntakeVariables({
+    dayId: '42',
+    meal: 'breakfast',
+    numServings: '1',
+    energyKcal: '',
+    proteinG: '',
+    fatG: '',
+    carbsG: '',
+  }).dayId, 42)
+})

--- a/webapp/tests/dashboard-overhaul.test.mjs
+++ b/webapp/tests/dashboard-overhaul.test.mjs
@@ -6,6 +6,7 @@ import {
   buildTrendCoordinates,
   buildWeightTrendSeries,
   describeWeightTrendChange,
+  isCurrentLocalDate,
   millisecondsUntilNextLocalDay,
   normalizeDateForComparison,
 } from '../src/components/dashboardHelpers.ts'
@@ -67,6 +68,14 @@ test('dashboard refresh helpers handle midnight rollover and flat trends', () =>
   assert.equal(describeWeightTrendChange(0), 'unchanged')
   assert.equal(describeWeightTrendChange(0.4), 'up 0.4 kilograms')
   assert.equal(describeWeightTrendChange(-0.4), 'down 0.4 kilograms')
+  assert.equal(
+    isCurrentLocalDate('2026-02-03', new Date(2026, 1, 3, 23, 59, 30)),
+    true,
+  )
+  assert.equal(
+    isCurrentLocalDate('2026-02-02', new Date(2026, 1, 3, 0, 0, 1)),
+    false,
+  )
 })
 
 test('dashboard query and actions include required data shape and remove hydration placeholder', async () => {
@@ -93,6 +102,10 @@ test('dashboard query and actions include required data shape and remove hydrati
   assert.match(dashboardSource, /flex justify-between text-xs text-slate-400/)
   assert.match(dashboardSource, /millisecondsUntilNextLocalDay/)
   assert.match(dashboardSource, /visibilitychange/)
+  assert.match(dashboardSource, /requestSequence/)
+  assert.match(dashboardSource, /isCurrentLocalDate\(today\.day\)/)
+  assert.match(dashboardSource, /!loading && todayIsCurrent/)
+  assert.match(dashboardSource, /uppercase tracking-wider text-slate-400/)
   assert.doesNotMatch(dashboardSource, /Hydration/)
   assert.doesNotMatch(dashboardSource, /Measurement logging.*unavailable/i)
 })

--- a/webapp/tests/dashboard-overhaul.test.mjs
+++ b/webapp/tests/dashboard-overhaul.test.mjs
@@ -90,6 +90,7 @@ test('dashboard query and actions include required data shape and remove hydrati
   assert.match(dashboardSource, /role="progressbar"/)
   assert.match(dashboardSource, /aria-valuetext=/)
   assert.match(dashboardSource, /key=\{point\.id\}/)
+  assert.match(dashboardSource, /flex justify-between text-xs text-slate-400/)
   assert.match(dashboardSource, /millisecondsUntilNextLocalDay/)
   assert.match(dashboardSource, /visibilitychange/)
   assert.doesNotMatch(dashboardSource, /Hydration/)

--- a/webapp/tests/dashboard-overhaul.test.mjs
+++ b/webapp/tests/dashboard-overhaul.test.mjs
@@ -105,6 +105,7 @@ test('dashboard query and actions include required data shape and remove hydrati
   assert.match(dashboardSource, /requestSequence/)
   assert.match(dashboardSource, /isCurrentLocalDate\(today\.day\)/)
   assert.match(dashboardSource, /!loading && todayIsCurrent/)
+  assert.match(dashboardSource, /today && todayIsCurrent \?/)
   assert.match(dashboardSource, /uppercase tracking-wider text-slate-400/)
   assert.doesNotMatch(dashboardSource, /Hydration/)
   assert.doesNotMatch(dashboardSource, /Measurement logging.*unavailable/i)

--- a/webapp/tests/dashboard-overhaul.test.mjs
+++ b/webapp/tests/dashboard-overhaul.test.mjs
@@ -5,6 +5,8 @@ import test from 'node:test'
 import {
   buildTrendCoordinates,
   buildWeightTrendSeries,
+  describeWeightTrendChange,
+  millisecondsUntilNextLocalDay,
   normalizeDateForComparison,
 } from '../src/components/dashboardHelpers.ts'
 
@@ -58,6 +60,15 @@ test('measurement dates use the local calendar date across midnight offsets', ()
   assert.equal(normalizeDateForComparison('2026-02-03'), '2026-02-03')
 })
 
+test('dashboard refresh helpers handle midnight rollover and flat trends', () => {
+  const thirtySecondsBeforeMidnight = new Date(2026, 1, 3, 23, 59, 30)
+
+  assert.equal(millisecondsUntilNextLocalDay(thirtySecondsBeforeMidnight), 30_000)
+  assert.equal(describeWeightTrendChange(0), 'unchanged')
+  assert.equal(describeWeightTrendChange(0.4), 'up 0.4 kilograms')
+  assert.equal(describeWeightTrendChange(-0.4), 'down 0.4 kilograms')
+})
+
 test('dashboard query and actions include required data shape and remove hydration placeholder', async () => {
   const dashboardSource = await readFile(
     new URL('../src/components/Dashboard.tsx', import.meta.url),
@@ -79,6 +90,8 @@ test('dashboard query and actions include required data shape and remove hydrati
   assert.match(dashboardSource, /role="progressbar"/)
   assert.match(dashboardSource, /aria-valuetext=/)
   assert.match(dashboardSource, /key=\{point\.id\}/)
+  assert.match(dashboardSource, /millisecondsUntilNextLocalDay/)
+  assert.match(dashboardSource, /visibilitychange/)
   assert.doesNotMatch(dashboardSource, /Hydration/)
   assert.doesNotMatch(dashboardSource, /Measurement logging.*unavailable/i)
 })


### PR DESCRIPTION
## Summary
- replace the static dashboard cards with daily nutrition progress and primary meal/weight actions
- expose a bounded dashboard GraphQL payload containing the latest measurements and the timezone-aware current plan day
- prefill meal logging from the dashboard day and add an accessible recent-weight trend
- remove the unused hydration card and measurement placeholder

## Validation
- [x] Frontend test suite: 61 passed
- [x] TypeScript check
- [x] Next.js production build
- [x] Focused backend dashboard schema tests
- [x] Black and Flake8 checks for changed backend files
- [x] Read-only review-agent feedback addressed
- [ ] Full backend PostgreSQL suite (CI)
