### PR TITLE
feat: add accessible mobile navigation

### DIFF
--- a/webapp/cypress/e2e/measurements.feature
+++ b/webapp/cypress/e2e/measurements.feature
@@ -12,3 +12,16 @@ Feature: Measurements CRUD
     And I fill in the weight with "82.0"
     And I click the save button
     Then I should be redirected to the measurements list
+
+  Scenario: Navigate away from measurements on a phone
+    Given I am logged in
+    And I use a mobile viewport
+    When I navigate to the measurements page
+    Then I should see the mobile navigation
+    When I open the mobile navigation
+    Then I should see the open primary navigation
+    When I close the mobile navigation with Escape
+    Then the mobile menu button should have focus
+    When I open the mobile navigation
+    And I choose Plans from the mobile navigation
+    Then I should be on the plans page with the mobile navigation closed

--- a/webapp/cypress/support/step_definitions/measurements.ts
+++ b/webapp/cypress/support/step_definitions/measurements.ts
@@ -11,6 +11,50 @@ Then("I should see the measurements page title", () => {
         .and("contain.text", "Measurements");
 });
 
+When("I use a mobile viewport", () => {
+    cy.viewport(375, 667);
+});
+
+Then("I should see the mobile navigation", () => {
+    cy.get('[aria-label="Go to dashboard"]').should("be.visible");
+    cy.get('[aria-label="Open navigation menu"]')
+        .should("be.visible")
+        .and("have.attr", "aria-expanded", "false");
+    cy.get('[aria-label="Primary navigation"]').should("not.be.visible");
+});
+
+When("I open the mobile navigation", () => {
+    cy.get('[aria-label="Open navigation menu"]').click();
+});
+
+Then("I should see the open primary navigation", () => {
+    cy.get('[aria-label="Open navigation menu"]')
+        .should("have.attr", "aria-expanded", "true");
+    cy.get('[aria-label="Primary navigation"]').should("be.visible");
+});
+
+When("I close the mobile navigation with Escape", () => {
+    cy.get("body").trigger("keydown", { key: "Escape" });
+});
+
+Then("the mobile menu button should have focus", () => {
+    cy.get('[aria-label="Open navigation menu"]')
+        .should("have.attr", "aria-expanded", "false")
+        .and("be.focused");
+});
+
+When("I choose Plans from the mobile navigation", () => {
+    cy.get('[data-testid="nav-week-plans"]').click();
+});
+
+Then("I should be on the plans page with the mobile navigation closed", () => {
+    cy.location("pathname").should("equal", "/plans");
+    cy.get('[aria-label="Open navigation menu"]')
+        .should("have.attr", "aria-expanded", "false");
+    cy.get('[aria-label="Primary navigation"]').should("not.be.visible");
+    cy.get(".main-content").should("be.focused");
+});
+
 When("I navigate to the new measurement page", () => {
     cy.visit("/measurements/new");
     waitForFormReady();

--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -97,6 +97,12 @@ body {
   min-height: 100vh;
 }
 
+.mobile-header,
+.sidebar-close,
+.sidebar-overlay {
+  display: none;
+}
+
 /* Data Table */
 .data-table {
   width: 100%;
@@ -373,10 +379,75 @@ textarea.form-input {
 
 /* Responsive */
 @media (max-width: 768px) {
+  .mobile-header {
+    position: fixed;
+    inset: 0 0 auto 0;
+    z-index: 45;
+    display: flex;
+    height: 4rem;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 1rem;
+    background: rgba(15, 17, 26, 0.95);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--card-border);
+  }
+
+  .mobile-header-button,
+  .sidebar-close {
+    display: inline-flex;
+    width: 2.75rem;
+    height: 2.75rem;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    border-radius: 0.5rem;
+    background: transparent;
+    color: #e2e8f0;
+    cursor: pointer;
+  }
+
+  .mobile-header-button:hover,
+  .mobile-header-button:focus-visible,
+  .sidebar-close:hover,
+  .sidebar-close:focus-visible {
+    background: rgba(255, 255, 255, 0.08);
+    outline: 2px solid transparent;
+  }
+
   .sidebar {
     transform: translateX(-100%);
+    visibility: hidden;
+    transition: transform 0.2s ease, visibility 0.2s;
+    z-index: 60;
   }
+
+  .sidebar.open {
+    transform: translateX(0);
+    visibility: visible;
+  }
+
+  .sidebar-close {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+
+  .sidebar-overlay.open {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    background: rgba(2, 6, 23, 0.72);
+    cursor: pointer;
+  }
+
   .main-content {
     margin-left: 0;
+    padding-top: 5.5rem !important;
   }
 }

--- a/webapp/src/components/AppShell.tsx
+++ b/webapp/src/components/AppShell.tsx
@@ -69,7 +69,7 @@ function AppShellInner({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Sidebar />
-      <main className="main-content p-6 md:p-10">
+      <main className="main-content p-6 md:p-10" tabIndex={-1}>
         {children}
       </main>
     </>

--- a/webapp/src/components/Sidebar.tsx
+++ b/webapp/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { useSession, signOut } from 'next-auth/react'
 import {
@@ -18,6 +19,8 @@ import {
   Weight,
   Calendar,
   CalendarDays,
+  Menu,
+  X,
 } from 'lucide-react'
 
 interface NavItem {
@@ -70,53 +73,192 @@ const navSections: NavSection[] = [
   },
 ]
 
+function focusMainContent() {
+  requestAnimationFrame(() => {
+    document.querySelector<HTMLElement>('.main-content')?.focus({ preventScroll: true })
+  })
+}
+
 export default function Sidebar() {
   const pathname = usePathname()
   const { data: session } = useSession()
+  const authenticated = Boolean(session)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuButtonRef = useRef<HTMLButtonElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const drawerRef = useRef<HTMLElement>(null)
+  const previousPathnameRef = useRef(pathname)
+
+  const closeMenu = useCallback(() => {
+    setMenuOpen(false)
+    requestAnimationFrame(() => menuButtonRef.current?.focus())
+  }, [])
+
+  useEffect(() => {
+    if (previousPathnameRef.current === pathname) return
+    previousPathnameRef.current = pathname
+    setMenuOpen(false)
+    focusMainContent()
+  }, [pathname])
+
+  useEffect(() => {
+    if (!authenticated) setMenuOpen(false)
+  }, [authenticated])
+
+  useEffect(() => {
+    if (!menuOpen || !authenticated) return
+
+    const mobileMedia = window.matchMedia('(max-width: 768px)')
+    if (!mobileMedia.matches) {
+      setMenuOpen(false)
+      focusMainContent()
+      return
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeMenu()
+        return
+      }
+
+      if (event.key === 'Tab') {
+        const focusable = Array.from(
+          drawerRef.current?.querySelectorAll<HTMLElement>(
+            'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+          ) ?? [],
+        )
+        if (focusable.length === 0) return
+
+        const first = focusable[0]
+        const last = focusable[focusable.length - 1]
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault()
+          last.focus()
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    const handleBreakpointChange = (event: MediaQueryListEvent) => {
+      if (!event.matches) {
+        setMenuOpen(false)
+        focusMainContent()
+      }
+    }
+
+    const previousOverflow = document.body.style.overflow
+    const mainContent = document.querySelector<HTMLElement>('.main-content')
+    const mobileHeader = document.querySelector<HTMLElement>('.mobile-header')
+    const mainWasInert = mainContent?.hasAttribute('inert') ?? false
+    const headerWasInert = mobileHeader?.hasAttribute('inert') ?? false
+    document.body.style.overflow = 'hidden'
+    mainContent?.setAttribute('inert', '')
+    mobileHeader?.setAttribute('inert', '')
+    document.addEventListener('keydown', handleKeyDown)
+    mobileMedia.addEventListener('change', handleBreakpointChange)
+    closeButtonRef.current?.focus()
+
+    return () => {
+      document.body.style.overflow = previousOverflow
+      if (!mainWasInert) mainContent?.removeAttribute('inert')
+      if (!headerWasInert) mobileHeader?.removeAttribute('inert')
+      document.removeEventListener('keydown', handleKeyDown)
+      mobileMedia.removeEventListener('change', handleBreakpointChange)
+    }
+  }, [authenticated, closeMenu, menuOpen])
 
   if (!session) return null
 
   return (
-    <nav className="sidebar" data-testid="sidebar">
-      <div className="px-6 mb-6">
-        <Link href="/" className="text-xl font-black tracking-tight text-white no-underline">
+    <>
+      <header className="mobile-header">
+        <Link href="/" aria-label="Go to dashboard" className="mobile-header-button">
+          <Home size={22} aria-hidden="true" />
+        </Link>
+        <Link href="/" className="text-lg font-black tracking-tight no-underline">
           <span className="text-gradient">Nutrition</span>
         </Link>
-      </div>
-
-      {navSections.map((section) => (
-        <div key={section.title || 'main'}>
-          {section.title && (
-            <div className="sidebar-section">{section.title}</div>
-          )}
-          {section.items.map((item) => {
-            const isActive = pathname === item.href ||
-              (item.href !== '/' && pathname.startsWith(item.href))
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={`sidebar-link ${isActive ? 'active' : ''}`}
-                data-testid={`nav-${item.label.toLowerCase().replace(/\s+/g, '-')}`}
-              >
-                {item.icon}
-                {item.label}
-              </Link>
-            )
-          })}
-        </div>
-      ))}
-
-      <div className="mt-auto pt-6 border-t border-white/5 mx-4">
         <button
-          onClick={() => signOut()}
-          className="sidebar-link w-full text-left"
-          data-testid="nav-logout"
+          ref={menuButtonRef}
+          type="button"
+          className="mobile-header-button"
+          aria-label="Open navigation menu"
+          aria-expanded={menuOpen}
+          aria-controls="primary-navigation"
+          onClick={() => setMenuOpen(true)}
         >
-          <LogOut size={18} />
-          Sign Out
+          <Menu size={24} aria-hidden="true" />
         </button>
-      </div>
-    </nav>
+      </header>
+      <button
+        type="button"
+        className={`sidebar-overlay ${menuOpen ? 'open' : ''}`}
+        aria-label="Close navigation menu"
+        tabIndex={-1}
+        onClick={closeMenu}
+      />
+      <nav
+        ref={drawerRef}
+        id="primary-navigation"
+        aria-label="Primary navigation"
+        className={`sidebar ${menuOpen ? 'open' : ''}`}
+        data-testid="sidebar"
+      >
+        <button
+          ref={closeButtonRef}
+          type="button"
+          className="sidebar-close"
+          aria-label="Close navigation menu"
+          onClick={closeMenu}
+        >
+          <X size={24} aria-hidden="true" />
+        </button>
+        <div className="px-6 mb-6">
+          <Link href="/" className="text-xl font-black tracking-tight text-white no-underline">
+            <span className="text-gradient">Nutrition</span>
+          </Link>
+        </div>
+
+        {navSections.map((section) => (
+          <div key={section.title || 'main'}>
+            {section.title && (
+              <div className="sidebar-section">{section.title}</div>
+            )}
+            {section.items.map((item) => {
+              const isActive = pathname === item.href ||
+                (item.href !== '/' && pathname.startsWith(item.href))
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`sidebar-link ${isActive ? 'active' : ''}`}
+                  data-testid={`nav-${item.label.toLowerCase().replace(/\s+/g, '-')}`}
+                  onClick={closeMenu}
+                >
+                  {item.icon}
+                  {item.label}
+                </Link>
+              )
+            })}
+          </div>
+        ))}
+
+        <div className="mt-auto pt-6 border-t border-white/5 mx-4">
+          <button
+            onClick={() => {
+              closeMenu()
+              void signOut()
+            }}
+            className="sidebar-link w-full text-left"
+            data-testid="nav-logout"
+          >
+            <LogOut size={18} />
+            Sign Out
+          </button>
+        </div>
+      </nav>
+    </>
   )
 }

--- a/webapp/tests/mobile-navigation.test.mjs
+++ b/webapp/tests/mobile-navigation.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const readSource = (path) => readFile(new URL(path, import.meta.url), 'utf8')
+
+test('authenticated mobile pages expose an accessible home bar and closable navigation drawer', async () => {
+  const [shellSource, sidebarSource, styles] = await Promise.all([
+    readSource('../src/components/AppShell.tsx'),
+    readSource('../src/components/Sidebar.tsx'),
+    readSource('../src/app/globals.css'),
+  ])
+
+  assert.match(shellSource, /<Sidebar \/>/)
+  assert.match(shellSource, /<main className="main-content p-6 md:p-10" tabIndex=\{-1\}>/)
+  assert.match(sidebarSource, /className="mobile-header"/)
+  assert.match(sidebarSource, /href="\/"/)
+  assert.match(sidebarSource, /aria-label="Go to dashboard"/)
+  assert.match(sidebarSource, /aria-label="Open navigation menu"/)
+  assert.match(sidebarSource, /aria-expanded=\{menuOpen\}/)
+  assert.match(sidebarSource, /aria-controls="primary-navigation"/)
+  assert.match(sidebarSource, /event\.key === 'Escape'/)
+  assert.match(sidebarSource, /event\.key === 'Tab'/)
+  assert.match(sidebarSource, /drawerRef\.current\?\.querySelectorAll/)
+  assert.match(sidebarSource, /menuButtonRef\.current\?\.focus\(\)/)
+  assert.match(sidebarSource, /window\.matchMedia\('\(max-width: 768px\)'\)/)
+  assert.match(sidebarSource, /if \(!menuOpen \|\| !authenticated\) return/)
+  assert.match(sidebarSource, /mainContent\?\.setAttribute\('inert', ''\)/)
+  assert.match(sidebarSource, /mobileHeader\?\.setAttribute\('inert', ''\)/)
+  assert.match(sidebarSource, /focusMainContent\(\)/)
+  assert.match(sidebarSource, /className=\{`sidebar-overlay \$\{menuOpen \? 'open' : ''\}`\}/)
+
+  assert.match(sidebarSource, /id="primary-navigation"/)
+  assert.match(sidebarSource, /aria-label="Primary navigation"/)
+  assert.match(sidebarSource, /className=\{`sidebar \$\{menuOpen \? 'open' : ''\}`\}/)
+  assert.match(sidebarSource, /aria-label="Close navigation menu"/)
+  assert.match(sidebarSource, /onClick=\{closeMenu\}/)
+
+  assert.match(styles, /\.mobile-header,[\s\S]*\.sidebar-overlay\s*\{[^}]*display:\s*none/s)
+  assert.match(styles, /@media \(max-width: 768px\)[\s\S]*\.mobile-header\s*\{[^}]*display:\s*flex/s)
+  assert.match(styles, /\.sidebar\.open\s*\{[^}]*transform:\s*translateX\(0\)/s)
+  assert.match(styles, /\.sidebar-overlay\.open\s*\{[^}]*display:\s*block/s)
+  assert.match(styles, /\.main-content\s*\{[^}]*padding-top:/s)
+})
+
+test('mobile navigation has a browser-level Cypress acceptance scenario', async () => {
+  const [feature, steps] = await Promise.all([
+    readSource('../cypress/e2e/measurements.feature'),
+    readSource('../cypress/support/step_definitions/measurements.ts'),
+  ])
+
+  assert.match(feature, /Scenario: Navigate away from measurements on a phone/)
+  assert.match(feature, /When I open the mobile navigation/)
+  assert.match(feature, /When I close the mobile navigation with Escape/)
+  assert.match(feature, /Then the mobile menu button should have focus/)
+  assert.match(feature, /And I choose Plans from the mobile navigation/)
+  assert.match(feature, /Then I should be on the plans page with the mobile navigation closed/)
+  assert.match(steps, /cy\.viewport\(375, 667\)/)
+  assert.match(steps, /aria-expanded.*true/)
+  assert.match(steps, /trigger\("keydown", \{ key: "Escape" \}\)/)
+  assert.match(steps, /and\("be\.focused"\)/)
+  assert.match(steps, /cy\.get\("\.main-content"\)\.should\("be\.focused"\)/)
+})


### PR DESCRIPTION
## Summary
- add a persistent mobile header with Home and menu controls
- turn the existing sidebar into an accessible off-canvas navigation drawer on small screens
- trap and restore focus, isolate background content, and clean up on route, session, and viewport changes
- add Node contract coverage and an authenticated Cypress mobile navigation scenario

## Verification
- `npm test` — 64/64 passed
- `npm run build` — passed
- `npx tsc --noEmit --incremental false --ignoreDeprecations 6.0` — passed
- `npx cypress verify` — passed
- `git diff --check` — passed

## Notes
- the new Cypress scenario is included for CI execution against the complete application stack
