### PR TITLE
fix(webapp): bump nanoid to 3.3.17 to clear GHSA-2v37-7h3g-55p8

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -10007,9 +10007,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -53,6 +53,7 @@
     "picomatch@2": "2.3.2",
     "picomatch@>=3": "4.0.5",
     "postcss": "8.5.25",
+    "nanoid": "3.3.17",
     "systeminformation": "5.33.1",
     "tmp": "0.2.7",
     "tsx": "4.23.1",


### PR DESCRIPTION
The newly published GHSA-2v37-7h3g-55p8 (high, nanoid < 3.3.17 and 4.0.0-5.1.5) fails the webapp production dependency audit gate on every branch, including main — it is not caused by any specific PR.

nanoid 3.3.16 is pulled in transitively via postcss. This pins an override to the patched 3.3.17, following the existing transitive-pin pattern in webapp's overrides block.

Verified locally: `npm audit --omit=dev --audit-level=high` reports no vulnerabilities.