### PR TITLE
fix(staging): skip DB restore when backup credentials are unusable

### DIFF
--- a/platform/k8s/overlays/staging/db-restore-patch.yaml
+++ b/platform/k8s/overlays/staging/db-restore-patch.yaml
@@ -38,6 +38,25 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
+              if [ "${SKIP_DB_RESTORE:-false}" = "true" ]; then
+                echo "SKIP_DB_RESTORE=true. Applying schema migrations only."
+                /srv/www/backend/.venv/bin/python manage.py migrate --noinput
+                exit 0
+              fi
+
+              if [ ! -f "/mnt/secret/nutrition-gcp-db-backup-credentials.json" ]; then
+                echo "No backup credentials available. Skipping restore and running migrations."
+                /srv/www/backend/.venv/bin/python manage.py migrate --noinput
+                exit 0
+              fi
+
+              # A placeholder or malformed credentials file must not block startup.
+              if ! /srv/www/backend/.venv/bin/python -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get('client_email') and d.get('private_key') else 1)" /mnt/secret/nutrition-gcp-db-backup-credentials.json; then
+                echo "Backup credentials file is invalid. Skipping restore and running migrations."
+                /srv/www/backend/.venv/bin/python manage.py migrate --noinput
+                exit 0
+              fi
+
               echo "Waiting for database to be ready...";
               until pg_isready -h "$POSTGRESQL_HOST" -U "nutrition"; do
                 echo "Database not ready, waiting 2 seconds...";


### PR DESCRIPTION
## Problem

Preview namespaces get placeholder GCP backup credentials (`{}`), but the `db-restore` init container in the staging overlay ran the restore unconditionally → `DefaultCredentialsError` → backend stuck in `Init:CrashLoopBackOff`. Preview environments render manifests from the trusted branch, so the guard has to live here.

This is the same fix present in [#383](https://github.com/LuisMunozVillarreal/nutrition/pull/383) (`f074eda`); landing it in main first is what unblocks the #383 preview (and every other branch preview).

## Change

Three fail-open guards before the restore (all fall back to `manage.py migrate` so the backend can start):

- `SKIP_DB_RESTORE=true` env escape hatch
- missing credentials file
- invalid/placeholder credentials content (no `client_email`/`private_key`)

Staging behavior unchanged: real credentials pass the guards and the restore runs as before.

## Verification

- Guard logic tested locally for all three paths (placeholder → skip, real → proceed, missing → skip)
- `kubectl kustomize` renders the overlay cleanly with the guard in the Deployment
- No deployment identifiers in the diff