### PR TITLE
Add selectable weight trend ranges

### DIFF
--- a/webapp/src/app/measurements/page.tsx
+++ b/webapp/src/app/measurements/page.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { graphqlRequest, gql } from '@/lib/graphql'
 import DataTable, { Column } from '@/components/DataTable'
 import { subscribeToPromise } from '@/lib/promiseSubscription'
+import { buildWeightTrendSeries } from '@/components/dashboardHelpers'
+import WeightTrendChart from '@/components/WeightTrendChart'
 
 const MEASUREMENTS_QUERY = gql`
   query {
@@ -31,6 +33,57 @@ interface Measurement {
   createdAt: string
 }
 
+type RangeSelection = 'lastMonth' | 'lastQuarter' | 'lastYear' | 'custom'
+type PresetRangeSelection = Exclude<RangeSelection, 'custom'>
+
+interface DateRange {
+  startDate: string
+  endDate: string
+}
+
+const PRESETS: { label: string; value: RangeSelection }[] = [
+  { label: 'Last month', value: 'lastMonth' },
+  { label: 'Last quarter', value: 'lastQuarter' },
+  { label: 'Last year', value: 'lastYear' },
+  { label: 'Custom', value: 'custom' },
+]
+
+const PRESET_DAY_SPANS: Record<PresetRangeSelection, number> = {
+  lastMonth: 30,
+  lastQuarter: 90,
+  lastYear: 365,
+}
+
+const RANGE_LABELS: Record<RangeSelection, string> = {
+  lastMonth: 'Last month',
+  lastQuarter: 'Last quarter',
+  lastYear: 'Last year',
+  custom: 'Custom',
+}
+
+function formatInputDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${year}-${month}-${day}`
+}
+
+function computeRangePreset(value: PresetRangeSelection, now: Date): DateRange {
+  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const start = new Date(end)
+  start.setDate(end.getDate() - (PRESET_DAY_SPANS[value] - 1))
+
+  return { startDate: formatInputDate(start), endDate: formatInputDate(end) }
+}
+
+function validateCustomRange(startDate: string, endDate: string): string | null {
+  if (!startDate || !endDate) return 'Pick both a start and end date to use a custom range.'
+  if (startDate > endDate) return 'Start date must be on or before end date.'
+
+  return null
+}
+
 const columns: Column<Measurement>[] = [
   { key: 'id', label: 'ID', accessor: (r) => r.id },
   {
@@ -50,6 +103,10 @@ const columns: Column<Measurement>[] = [
 export default function MeasurementsPage() {
   const [data, setData] = useState<Measurement[]>([])
   const [loading, setLoading] = useState(true)
+  const [rangeSelection, setRangeSelection] = useState<RangeSelection>('lastMonth')
+  const today = useMemo(() => new Date(), [])
+  const [customStartDate, setCustomStartDate] = useState(formatInputDate(new Date(today.getFullYear(), today.getMonth(), today.getDate() - 29)))
+  const [customEndDate, setCustomEndDate] = useState(formatInputDate(today))
 
   const loadData = () => graphqlRequest<{ measurements: Measurement[] }>(MEASUREMENTS_QUERY)
   const applyData = (res: { measurements: Measurement[] }) => setData(res.measurements)
@@ -77,9 +134,105 @@ export default function MeasurementsPage() {
     }
   }
 
+  const selectedRange = useMemo(() => {
+    if (rangeSelection === 'custom') {
+      const error = validateCustomRange(customStartDate, customEndDate)
+
+      if (error) return { startDate: '', endDate: '', error }
+
+      return {
+        startDate: customStartDate,
+        endDate: customEndDate,
+        error: null,
+      }
+    }
+
+    return { ...computeRangePreset(rangeSelection, today), error: null }
+  }, [rangeSelection, today, customStartDate, customEndDate])
+
+  const series = useMemo(() => {
+    if (selectedRange.error) return []
+
+    return buildWeightTrendSeries(data, undefined, {
+      startDate: selectedRange.startDate,
+      endDate: selectedRange.endDate,
+    })
+  }, [data, selectedRange])
+
+  const validRangeMessage = rangeSelection === 'custom' && selectedRange.error
+    ? selectedRange.error
+    : null
+
+  const rangeLabel = rangeSelection === 'custom'
+    ? `${customStartDate} to ${customEndDate}`
+    : RANGE_LABELS[rangeSelection]
+
   return (
     <div>
       <h1 className="page-title mb-6" data-testid="measurements-title">Measurements</h1>
+      <section className="glass-card mb-6 rounded-3xl p-6" aria-labelledby="weight-range-title">
+        <div className="mb-4">
+          <h2 id="weight-range-title" className="text-xl font-bold">Weight trend</h2>
+          <p className="text-sm text-slate-400">Showing measurements for: {rangeLabel}</p>
+        </div>
+        <div className="mb-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <label htmlFor="trend-range" className="flex w-full flex-col gap-1">
+            <span className="text-xs font-semibold uppercase tracking-widest text-slate-300">Trend range</span>
+            <select
+              id="trend-range"
+              aria-label="Trend range"
+              value={rangeSelection}
+              onChange={(event) => setRangeSelection(event.target.value as RangeSelection)}
+              className="rounded-xl border border-white/20 bg-slate-900/50 px-3 py-2"
+            >
+              {PRESETS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+          </label>
+          <label htmlFor="trend-start-date" className="flex w-full flex-col gap-1">
+            <span className="text-xs font-semibold uppercase tracking-widest text-slate-300">Start date</span>
+            <input
+              id="trend-start-date"
+              type="date"
+              value={customStartDate}
+              onChange={(event) => setCustomStartDate(event.target.value)}
+              aria-describedby={validRangeMessage ? 'trend-range-error' : undefined}
+              disabled={rangeSelection !== 'custom'}
+              className="rounded-xl border border-white/20 bg-slate-900/50 px-3 py-2"
+            />
+          </label>
+          <label htmlFor="trend-end-date" className="flex w-full flex-col gap-1">
+            <span className="text-xs font-semibold uppercase tracking-widest text-slate-300">End date</span>
+            <input
+              id="trend-end-date"
+              type="date"
+              value={customEndDate}
+              onChange={(event) => setCustomEndDate(event.target.value)}
+              aria-describedby={validRangeMessage ? 'trend-range-error' : undefined}
+              disabled={rangeSelection !== 'custom'}
+              className="rounded-xl border border-white/20 bg-slate-900/50 px-3 py-2"
+            />
+          </label>
+        </div>
+        {validRangeMessage && (
+          <p id="trend-range-error" role="alert" className="mb-2 text-sm text-red-300" aria-live="polite">
+            {validRangeMessage}
+          </p>
+        )}
+        {loading ? (
+          <div className="h-44 rounded-2xl bg-white/5 animate-pulse" />
+        ) : (
+          <WeightTrendChart
+            series={series}
+            emptyMessage={selectedRange.error
+              ? selectedRange.error
+              : series.length === 0
+                ? 'No measurements found for this date range.'
+                : 'Log at least two measurements to see your trend'}
+            emptyActionHref="/measurements/new"
+            emptyActionLabel="Log weight"
+          />
+        )}
+      </section>
       <DataTable
         columns={columns}
         data={data}

--- a/webapp/src/app/measurements/page.tsx
+++ b/webapp/src/app/measurements/page.tsx
@@ -234,14 +234,12 @@ export default function MeasurementsPage() {
         )}
         {loading ? (
           <div className="h-44 rounded-2xl bg-white/5 animate-pulse" />
-        ) : (
+        ) : selectedRange.error ? null : (
           <WeightTrendChart
             series={series}
-            emptyMessage={selectedRange.error
-              ? selectedRange.error
-              : series.length === 0
-                ? 'No measurements found for this date range.'
-                : 'Log at least two measurements to see your trend'}
+            emptyMessage={series.length === 0
+              ? 'No measurements found for this date range.'
+              : 'Log at least two measurements to see your trend'}
             emptyActionHref="/measurements/new"
             emptyActionLabel="Log weight"
           />

--- a/webapp/src/app/measurements/page.tsx
+++ b/webapp/src/app/measurements/page.tsx
@@ -4,7 +4,10 @@ import { useEffect, useMemo, useState } from 'react'
 import { graphqlRequest, gql } from '@/lib/graphql'
 import DataTable, { Column } from '@/components/DataTable'
 import { subscribeToPromise } from '@/lib/promiseSubscription'
-import { buildWeightTrendSeries } from '@/components/dashboardHelpers'
+import {
+  buildWeightTrendSeries,
+  millisecondsUntilNextLocalDay,
+} from '@/components/dashboardHelpers'
 import WeightTrendChart from '@/components/WeightTrendChart'
 
 const MEASUREMENTS_QUERY = gql`
@@ -104,7 +107,7 @@ export default function MeasurementsPage() {
   const [data, setData] = useState<Measurement[]>([])
   const [loading, setLoading] = useState(true)
   const [rangeSelection, setRangeSelection] = useState<RangeSelection>('lastMonth')
-  const today = useMemo(() => new Date(), [])
+  const [today, setToday] = useState(() => new Date())
   const [customStartDate, setCustomStartDate] = useState(formatInputDate(new Date(today.getFullYear(), today.getMonth(), today.getDate() - 29)))
   const [customEndDate, setCustomEndDate] = useState(formatInputDate(today))
 
@@ -123,6 +126,15 @@ export default function MeasurementsPage() {
     onRejected: reportLoadError,
     onSettled: finishLoading,
   }), [])
+
+  useEffect(() => {
+    const timer = setTimeout(
+      () => setToday(new Date()),
+      millisecondsUntilNextLocalDay(today),
+    )
+
+    return () => clearTimeout(timer)
+  }, [today])
 
   const handleDelete = async (row: Measurement) => {
     if (!confirm('Delete this measurement?')) return
@@ -195,6 +207,7 @@ export default function MeasurementsPage() {
               type="date"
               value={customStartDate}
               onChange={(event) => setCustomStartDate(event.target.value)}
+              aria-invalid={Boolean(validRangeMessage)}
               aria-describedby={validRangeMessage ? 'trend-range-error' : undefined}
               disabled={rangeSelection !== 'custom'}
               className="rounded-xl border border-white/20 bg-slate-900/50 px-3 py-2"
@@ -207,6 +220,7 @@ export default function MeasurementsPage() {
               type="date"
               value={customEndDate}
               onChange={(event) => setCustomEndDate(event.target.value)}
+              aria-invalid={Boolean(validRangeMessage)}
               aria-describedby={validRangeMessage ? 'trend-range-error' : undefined}
               disabled={rangeSelection !== 'custom'}
               className="rounded-xl border border-white/20 bg-slate-900/50 px-3 py-2"

--- a/webapp/src/components/Dashboard.tsx
+++ b/webapp/src/components/Dashboard.tsx
@@ -7,13 +7,12 @@ import Link from 'next/link'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { gql, graphqlRequest } from '@/lib/graphql'
 import {
-  buildTrendCoordinates,
   buildWeightTrendSeries,
-  describeWeightTrendChange,
   isCurrentLocalDate,
   millisecondsUntilNextLocalDay,
   type DashboardMeasurement,
 } from './dashboardHelpers'
+import WeightTrendChart from './WeightTrendChart'
 
 const DASHBOARD_QUERY = gql`
   query GetDashboard($timezoneOffsetMinutes: Int!) {
@@ -127,7 +126,7 @@ export default function Dashboard() {
   const summary = response?.me?.dashboard
   // Memoize the fallback so the dependency identity stays stable across renders.
   const measurements = useMemo(() => summary?.recentMeasurements ?? [], [summary?.recentMeasurements])
-  const trend = useMemo(() => buildWeightTrendSeries(measurements), [measurements])
+  const trend = useMemo(() => buildWeightTrendSeries(measurements, 14), [measurements])
   const latestMeasurement = measurements.at(-1)
   const today = summary?.todayNutrition ?? null
   const todayIsCurrent = today !== null && isCurrentLocalDate(today.day)
@@ -250,37 +249,14 @@ export default function Dashboard() {
           </Link>
         </div>
         {loading ? <div className="h-40 animate-pulse rounded-2xl bg-white/5" /> : (
-          <WeightTrend series={trend} />
+          <WeightTrendChart
+            series={trend}
+            emptyMessage="Log at least two measurements to see your trend"
+            emptyActionHref="/measurements/new"
+            emptyActionLabel="Log weight"
+          />
         )}
       </motion.section>
-    </div>
-  )
-}
-
-function WeightTrend({ series }: { series: ReturnType<typeof buildWeightTrendSeries> }) {
-  if (series.length < 2) {
-    return <EmptyValue message="Log at least two measurements to see your trend" href="/measurements/new" linkText="Log weight" />
-  }
-  const plot = buildTrendCoordinates(series, { width: 720, height: 180, padding: 20 })
-  const first = series[0]
-  const last = series.at(-1)!
-  const change = last.weight - first.weight
-  const label = `Weight trend from ${first.weight} kilograms to ${last.weight} kilograms, ${describeWeightTrendChange(change)}`
-
-  return (
-    <div>
-      <svg role="img" aria-label={label} viewBox={plot.viewBox} className="h-44 w-full" preserveAspectRatio="none">
-        <title>{label}</title>
-        <path d={plot.path} fill="none" stroke="rgb(192 132 252)" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round" vectorEffect="non-scaling-stroke" />
-        {plot.points.map((point) => (
-          <circle key={point.id} cx={point.x} cy={point.y} r="5" fill="rgb(216 180 254)">
-            <title>{`${point.date}: ${point.weight} kg`}</title>
-          </circle>
-        ))}
-      </svg>
-      <div className="flex justify-between text-xs text-slate-400">
-        <span>{first.date}</span><span>{last.date}</span>
-      </div>
     </div>
   )
 }

--- a/webapp/src/components/WeightTrendChart.tsx
+++ b/webapp/src/components/WeightTrendChart.tsx
@@ -1,0 +1,64 @@
+import {
+  buildTrendCoordinates,
+  describeWeightTrendChange,
+  type WeightTrendPoint,
+} from './dashboardHelpers'
+
+interface WeightTrendChartProps {
+  series: WeightTrendPoint[]
+  emptyMessage: string
+  emptyActionHref: string
+  emptyActionLabel: string
+}
+
+export default function WeightTrendChart({
+  series,
+  emptyMessage,
+  emptyActionHref,
+  emptyActionLabel,
+}: WeightTrendChartProps) {
+  if (series.length < 2) {
+    return (
+      <EmptyValue
+        message={emptyMessage}
+        href={emptyActionHref}
+        linkText={emptyActionLabel}
+      />
+    )
+  }
+
+  const plot = buildTrendCoordinates(series, { width: 720, height: 180, padding: 20 })
+  const first = series[0]
+  const last = series.at(-1)!
+  const change = last.weight - first.weight
+  const label = `Weight trend from ${first.weight} kilograms to ${last.weight} kilograms, ${describeWeightTrendChange(change)}`
+
+  return (
+    <div>
+      <svg role="img" aria-label={label} viewBox={plot.viewBox} className="h-44 w-full" preserveAspectRatio="none">
+        <title>{label}</title>
+        <path
+          d={plot.path}
+          fill="none"
+          stroke="rgb(192 132 252)"
+          strokeWidth="4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+        {plot.points.map((point) => (
+          <circle key={point.id} cx={point.x} cy={point.y} r="5" fill="rgb(216 180 254)">
+            <title>{`${point.date}: ${point.weight} kg`}</title>
+          </circle>
+        ))}
+      </svg>
+      <div className="flex justify-between text-xs text-slate-400">
+        <span>{first.date}</span><span>{last.date}</span>
+      </div>
+    </div>
+  )
+}
+
+function EmptyValue({ message, href, linkText }: { message: string; href: string; linkText: string }) {
+  return <div className="py-3"><p className="mb-2 text-slate-400">{message}</p><a href={href} className="text-sm font-bold text-purple-300 hover:text-purple-200">{linkText} →</a></div>
+}

--- a/webapp/src/components/dashboardHelpers.ts
+++ b/webapp/src/components/dashboardHelpers.ts
@@ -39,6 +39,20 @@ export function isCurrentLocalDate(value: string, now = new Date()): boolean {
   return value === normalizeDateForComparison(now.toISOString(), now.getTimezoneOffset())
 }
 
+function hasValidIsoCalendarDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})(?:T|$)/.exec(value)
+  if (!match) return false
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const parsed = new Date(Date.UTC(year, month - 1, day))
+
+  return parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() === month - 1
+    && parsed.getUTCDate() === day
+}
+
 export function buildWeightTrendSeries(
   measurements: DashboardMeasurement[],
   limit?: number,
@@ -53,7 +67,9 @@ export function buildWeightTrendSeries(
       timestamp: Date.parse(measurement.createdAt),
     }))
     .filter(({ measurement, timestamp }) => (
-      Number.isFinite(measurement.weight) && Number.isFinite(timestamp)
+      Number.isFinite(measurement.weight)
+      && Number.isFinite(timestamp)
+      && hasValidIsoCalendarDate(measurement.createdAt)
     ))
     .sort((a, b) => a.timestamp - b.timestamp)
 

--- a/webapp/src/components/dashboardHelpers.ts
+++ b/webapp/src/components/dashboardHelpers.ts
@@ -8,6 +8,7 @@ export interface DashboardMeasurement {
 export interface WeightTrendPoint {
   id: string
   date: string
+  timestamp: number
   weight: number
 }
 
@@ -40,15 +41,33 @@ export function isCurrentLocalDate(value: string, now = new Date()): boolean {
 
 export function buildWeightTrendSeries(
   measurements: DashboardMeasurement[],
-  limit = 14,
+  limit?: number,
+  dateRange?: { startDate?: string; endDate?: string },
 ): WeightTrendPoint[] {
-  return [...measurements]
+  const rangeStart = dateRange?.startDate
+  const rangeEnd = dateRange?.endDate
+
+  const ordered = [...measurements]
     .filter((measurement) => Number.isFinite(measurement.weight))
     .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
-    .slice(-limit)
+
+  const limited = ordered.filter((measurement) => {
+    const measurementDate = normalizeDateForComparison(measurement.createdAt)
+
+    if (rangeStart && measurementDate < rangeStart) return false
+    if (rangeEnd && measurementDate > rangeEnd) return false
+
+    return true
+  })
+  const series = (typeof limit === 'number' && limit > 0)
+    ? limited.slice(-limit)
+    : limited
+
+  return series
     .map((measurement) => ({
       id: measurement.id,
       date: normalizeDateForComparison(measurement.createdAt),
+      timestamp: Date.parse(measurement.createdAt),
       weight: measurement.weight,
     }))
 }
@@ -64,16 +83,17 @@ export function buildTrendCoordinates(
   const range = max - min
   const availableWidth = width - padding * 2
   const availableHeight = height - padding * 2
-  const timestamps = series.map((point) => Date.parse(point.date))
+  const timestamps = series.map((point) => point.timestamp)
   const firstTimestamp = timestamps[0]
   const elapsedTime = timestamps.at(-1)! - firstTimestamp
+  const boundedElapsedTime = elapsedTime > 0 ? elapsedTime : 0
 
   const points = series.map((point, index) => ({
     ...point,
     x:
-      series.length === 1 || elapsedTime === 0
+      series.length === 1 || boundedElapsedTime === 0
         ? width / 2
-        : padding + ((timestamps[index] - firstTimestamp) / elapsedTime) * availableWidth,
+        : padding + ((timestamps[index] - firstTimestamp) / boundedElapsedTime) * availableWidth,
     y:
       range === 0
         ? height / 2

--- a/webapp/src/components/dashboardHelpers.ts
+++ b/webapp/src/components/dashboardHelpers.ts
@@ -64,13 +64,16 @@ export function buildTrendCoordinates(
   const range = max - min
   const availableWidth = width - padding * 2
   const availableHeight = height - padding * 2
+  const timestamps = series.map((point) => Date.parse(point.date))
+  const firstTimestamp = timestamps[0]
+  const elapsedTime = timestamps.at(-1)! - firstTimestamp
 
   const points = series.map((point, index) => ({
     ...point,
     x:
-      series.length === 1
+      series.length === 1 || elapsedTime === 0
         ? width / 2
-        : padding + (index / (series.length - 1)) * availableWidth,
+        : padding + ((timestamps[index] - firstTimestamp) / elapsedTime) * availableWidth,
     y:
       range === 0
         ? height / 2

--- a/webapp/src/components/dashboardHelpers.ts
+++ b/webapp/src/components/dashboardHelpers.ts
@@ -47,11 +47,17 @@ export function buildWeightTrendSeries(
   const rangeStart = dateRange?.startDate
   const rangeEnd = dateRange?.endDate
 
-  const ordered = [...measurements]
-    .filter((measurement) => Number.isFinite(measurement.weight))
-    .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+  const ordered = measurements
+    .map((measurement) => ({
+      measurement,
+      timestamp: Date.parse(measurement.createdAt),
+    }))
+    .filter(({ measurement, timestamp }) => (
+      Number.isFinite(measurement.weight) && Number.isFinite(timestamp)
+    ))
+    .sort((a, b) => a.timestamp - b.timestamp)
 
-  const limited = ordered.filter((measurement) => {
+  const limited = ordered.filter(({ measurement }) => {
     const measurementDate = normalizeDateForComparison(measurement.createdAt)
 
     if (rangeStart && measurementDate < rangeStart) return false
@@ -64,10 +70,10 @@ export function buildWeightTrendSeries(
     : limited
 
   return series
-    .map((measurement) => ({
+    .map(({ measurement, timestamp }) => ({
       id: measurement.id,
       date: normalizeDateForComparison(measurement.createdAt),
-      timestamp: Date.parse(measurement.createdAt),
+      timestamp,
       weight: measurement.weight,
     }))
 }

--- a/webapp/tests/assigned-pages-runtime.test.mjs
+++ b/webapp/tests/assigned-pages-runtime.test.mjs
@@ -106,6 +106,7 @@ afterEach(() => {
   params = { id: '42' }
   searchParams = new URLSearchParams()
   vi.restoreAllMocks()
+  vi.useRealTimers()
 })
 
 const deferred = () => {
@@ -735,12 +736,38 @@ test('measurements page renders the reusable trend chart and validates custom da
 
   const rangeError = await screen.findByRole('alert')
   assert.equal(rangeError.textContent, 'Start date must be on or before end date.')
+  assert.equal(screen.getByLabelText('Start date').getAttribute('aria-invalid'), 'true')
+  assert.equal(screen.getByLabelText('End date').getAttribute('aria-invalid'), 'true')
 
   fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026-01-02' } })
   fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2026-01-03' } })
+  assert.equal(screen.getByLabelText('Start date').getAttribute('aria-invalid'), 'false')
+  assert.equal(screen.getByLabelText('End date').getAttribute('aria-invalid'), 'false')
   await screen.findByText('Weight trend')
   assert.ok(screen.getByRole('img', { name: /Weight trend from 81 kilograms to 80.8 kilograms/ }))
   assert.equal(requests.length, 1)
+})
+
+test('measurements preset ranges roll forward at local midnight', async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 0, 31, 23, 59, 59, 900))
+  responses = [{ measurements: [
+    { id: 'jan-2', bodyFatPerc: 20, weight: 70, bmr: 1600, createdAt: new Date(2026, 0, 2, 12).toISOString() },
+    { id: 'jan-31', bodyFatPerc: 19.8, weight: 69, bmr: 1605, createdAt: new Date(2026, 0, 31, 12).toISOString() },
+    { id: 'feb-1', bodyFatPerc: 19.6, weight: 68, bmr: 1598, createdAt: new Date(2026, 1, 1, 0).toISOString() },
+  ] }]
+
+  render(React.createElement(MeasurementsPage))
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+  assert.ok(screen.getByRole('img', { name: /Weight trend from 70 kilograms to 69 kilograms/ }))
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(200)
+  })
+  assert.ok(screen.getByRole('img', { name: /Weight trend from 69 kilograms to 68 kilograms/ }))
 })
 
 test('new measurement submits optional body fat without preloading it', async () => {

--- a/webapp/tests/assigned-pages-runtime.test.mjs
+++ b/webapp/tests/assigned-pages-runtime.test.mjs
@@ -707,11 +707,14 @@ test('measurements list loads rows and handles delete and fetch errors', async (
 })
 
 test('measurements page renders the reusable trend chart and validates custom date ranges', async () => {
-  responses = [{ measurements: [
-    { id: 'm3', bodyFatPerc: 20, weight: 81.2, bmr: 1600, createdAt: '2026-01-01T00:00:00Z' },
-    { id: 'm2', bodyFatPerc: 19.8, weight: 81, bmr: 1605, createdAt: '2026-01-02T00:00:00Z' },
-    { id: 'm1', bodyFatPerc: 19.6, weight: 80.8, bmr: 1598, createdAt: '2026-01-03T00:00:00Z' },
-  ] }]
+  const measurements = Array.from({ length: 20 }, (_, index) => ({
+    id: `m${index + 1}`,
+    bodyFatPerc: 20 - index / 10,
+    weight: 81 - index / 10,
+    bmr: 1600 + index,
+    createdAt: new Date(2026, 0, index + 1, 12).toISOString(),
+  }))
+  responses = [{ measurements }]
   render(React.createElement(MeasurementsPage))
   await waitForTableLoaded()
   assert.equal(requests.length, 1)
@@ -731,7 +734,7 @@ test('measurements page renders the reusable trend chart and validates custom da
     'Pick both a start and end date to use a custom range.',
   )
 
-  fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026-01-03' } })
+  fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026-01-20' } })
   fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2026-01-01' } })
 
   const rangeError = await screen.findByRole('alert')
@@ -739,12 +742,13 @@ test('measurements page renders the reusable trend chart and validates custom da
   assert.equal(screen.getByLabelText('Start date').getAttribute('aria-invalid'), 'true')
   assert.equal(screen.getByLabelText('End date').getAttribute('aria-invalid'), 'true')
 
-  fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026-01-02' } })
-  fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2026-01-03' } })
+  fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026-01-01' } })
+  fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2026-01-20' } })
   assert.equal(screen.getByLabelText('Start date').getAttribute('aria-invalid'), 'false')
   assert.equal(screen.getByLabelText('End date').getAttribute('aria-invalid'), 'false')
   await screen.findByText('Weight trend')
-  assert.ok(screen.getByRole('img', { name: /Weight trend from 81 kilograms to 80.8 kilograms/ }))
+  assert.ok(screen.getByRole('img', { name: /Weight trend from 81 kilograms to 79.1 kilograms/ }))
+  assert.equal(document.querySelectorAll('svg circle').length, 20)
   assert.equal(requests.length, 1)
 })
 

--- a/webapp/tests/assigned-pages-runtime.test.mjs
+++ b/webapp/tests/assigned-pages-runtime.test.mjs
@@ -705,6 +705,44 @@ test('measurements list loads rows and handles delete and fetch errors', async (
   assert.deepEqual(consoleError.mock.calls[1], ['Failed to fetch measurements', error])
 })
 
+test('measurements page renders the reusable trend chart and validates custom date ranges', async () => {
+  responses = [{ measurements: [
+    { id: 'm3', bodyFatPerc: 20, weight: 81.2, bmr: 1600, createdAt: '2026-01-01T00:00:00Z' },
+    { id: 'm2', bodyFatPerc: 19.8, weight: 81, bmr: 1605, createdAt: '2026-01-02T00:00:00Z' },
+    { id: 'm1', bodyFatPerc: 19.6, weight: 80.8, bmr: 1598, createdAt: '2026-01-03T00:00:00Z' },
+  ] }]
+  render(React.createElement(MeasurementsPage))
+  await waitForTableLoaded()
+  assert.equal(requests.length, 1)
+  assert.match(document.body.textContent, /Showing measurements for:/)
+  assert.match(document.body.textContent, /No measurements found for this date range/)
+
+  const rangeSelect = screen.getByLabelText('Trend range')
+  fireEvent.change(rangeSelect, { target: { value: 'lastQuarter' } })
+  assert.match(document.body.textContent, /Showing measurements for: Last quarter/)
+  fireEvent.change(rangeSelect, { target: { value: 'lastYear' } })
+  assert.match(document.body.textContent, /Showing measurements for: Last year/)
+  fireEvent.change(rangeSelect, { target: { value: 'custom' } })
+
+  fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '' } })
+  assert.equal(
+    (await screen.findByRole('alert')).textContent,
+    'Pick both a start and end date to use a custom range.',
+  )
+
+  fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026-01-03' } })
+  fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2026-01-01' } })
+
+  const rangeError = await screen.findByRole('alert')
+  assert.equal(rangeError.textContent, 'Start date must be on or before end date.')
+
+  fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026-01-02' } })
+  fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2026-01-03' } })
+  await screen.findByText('Weight trend')
+  assert.ok(screen.getByRole('img', { name: /Weight trend from 81 kilograms to 80.8 kilograms/ }))
+  assert.equal(requests.length, 1)
+})
+
 test('new measurement submits optional body fat without preloading it', async () => {
   const pending = deferred()
   responses = [() => pending.promise]

--- a/webapp/tests/assigned-pages-runtime.test.mjs
+++ b/webapp/tests/assigned-pages-runtime.test.mjs
@@ -739,6 +739,8 @@ test('measurements page renders the reusable trend chart and validates custom da
 
   const rangeError = await screen.findByRole('alert')
   assert.equal(rangeError.textContent, 'Start date must be on or before end date.')
+  assert.equal(screen.getAllByText('Start date must be on or before end date.').length, 1)
+  assert.equal(screen.queryByRole('link', { name: 'Log weight →' }), null)
   assert.equal(screen.getByLabelText('Start date').getAttribute('aria-invalid'), 'true')
   assert.equal(screen.getByLabelText('End date').getAttribute('aria-invalid'), 'true')
 

--- a/webapp/tests/dashboard-overhaul.test.mjs
+++ b/webapp/tests/dashboard-overhaul.test.mjs
@@ -105,8 +105,12 @@ test('trend helpers discard malformed timestamps before building finite SVG geom
   const points = buildWeightTrendSeries([
     { id: '1', createdAt: '2026-02-01', weight: 70.2, bodyFatPerc: 21 },
     { id: 'bad-date', createdAt: '2026-02-02-not-a-time', weight: 70.1, bodyFatPerc: 20.5 },
+    { id: 'non-iso-date', createdAt: 'February 2, 2026', weight: 70.1, bodyFatPerc: 20.5 },
+    { id: 'non-leap-day', createdAt: '2026-02-29T00:00:00Z', weight: 70.1, bodyFatPerc: 20.5 },
+    { id: 'february-30', createdAt: '2026-02-30T00:00:00Z', weight: 70.1, bodyFatPerc: 20.5 },
+    { id: 'april-31', createdAt: '2026-04-31T12:00:00Z', weight: 70.1, bodyFatPerc: 20.5 },
     { id: '3', createdAt: '2026-02-03', weight: 70, bodyFatPerc: 20.4 },
-  ], undefined, { startDate: '2026-02-01', endDate: '2026-02-03' })
+  ])
 
   assert.deepEqual(points.map((point) => point.id), ['1', '3'])
   const plot = buildTrendCoordinates(points, { width: 100, height: 80, padding: 10 })

--- a/webapp/tests/dashboard-overhaul.test.mjs
+++ b/webapp/tests/dashboard-overhaul.test.mjs
@@ -80,16 +80,38 @@ test('trend coordinate mapping reflects elapsed time even within the same day', 
   assert.deepEqual(plot.points.map((point) => point.x), [10, 90])
 })
 
-test('trend helpers filter by inclusive date ranges and avoid truncating by default', () => {
-  const points = buildWeightTrendSeries([
-    { id: '1', createdAt: '2026-02-01T00:00:00Z', weight: 70.2, bodyFatPerc: 21 },
-    { id: '2', createdAt: '2026-02-02T00:00:00Z', weight: 70.1, bodyFatPerc: 20.5 },
-    { id: '3', createdAt: '2026-02-03T00:00:00Z', weight: 70, bodyFatPerc: 20.4 },
-  ], undefined, { startDate: '2026-02-01', endDate: '2026-02-02' })
+test('trend helpers filter inclusive ranges without timezone assumptions or default truncation', () => {
+  const measurements = Array.from({ length: 20 }, (_, index) => ({
+    id: String(index + 1),
+    createdAt: `2026-02-${String(index + 1).padStart(2, '0')}`,
+    weight: 70 - index / 10,
+    bodyFatPerc: 21 - index / 20,
+  }))
 
-  assert.deepEqual(points.map((point) => point.id), ['1', '2'])
-  assert.deepEqual(points[0].date, '2026-02-01')
-  assert.deepEqual(points[1].date, '2026-02-02')
+  const points = buildWeightTrendSeries(
+    measurements,
+    undefined,
+    { startDate: '2026-02-01', endDate: '2026-02-20' },
+  )
+
+  assert.equal(points.length, 20)
+  assert.equal(points[0].id, '1')
+  assert.equal(points.at(-1).id, '20')
+  assert.equal(points[0].date, '2026-02-01')
+  assert.equal(points.at(-1).date, '2026-02-20')
+})
+
+test('trend helpers discard malformed timestamps before building finite SVG geometry', () => {
+  const points = buildWeightTrendSeries([
+    { id: '1', createdAt: '2026-02-01', weight: 70.2, bodyFatPerc: 21 },
+    { id: 'bad-date', createdAt: '2026-02-02-not-a-time', weight: 70.1, bodyFatPerc: 20.5 },
+    { id: '3', createdAt: '2026-02-03', weight: 70, bodyFatPerc: 20.4 },
+  ], undefined, { startDate: '2026-02-01', endDate: '2026-02-03' })
+
+  assert.deepEqual(points.map((point) => point.id), ['1', '3'])
+  const plot = buildTrendCoordinates(points, { width: 100, height: 80, padding: 10 })
+  assert.equal(plot.points.every((point) => Number.isFinite(point.x) && Number.isFinite(point.y)), true)
+  assert.doesNotMatch(plot.path, /NaN|Infinity/)
 })
 
 test('trend series filters non-finite weights and handles a single point', () => {

--- a/webapp/tests/dashboard-overhaul.test.mjs
+++ b/webapp/tests/dashboard-overhaul.test.mjs
@@ -49,6 +49,37 @@ test('trend coordinate mapping is bounded and stable for flat series', () => {
   assert.equal(typeof plot.viewBox, 'string')
 })
 
+test('trend coordinate mapping spaces measurements by elapsed time', () => {
+  const trendPoints = buildWeightTrendSeries([
+    { id: '1', createdAt: '2026-02-01T00:00:00Z', weight: 70, bodyFatPerc: 21 },
+    { id: '2', createdAt: '2026-02-02T00:00:00Z', weight: 69.8, bodyFatPerc: 20.5 },
+    { id: '3', createdAt: '2026-02-09T00:00:00Z', weight: 69.5, bodyFatPerc: 20 },
+  ], 3)
+
+  const plot = buildTrendCoordinates(trendPoints, {
+    width: 100,
+    height: 80,
+    padding: 10,
+  })
+
+  assert.deepEqual(plot.points.map((point) => point.x), [10, 20, 90])
+})
+
+test('trend coordinate mapping centres measurements from the same date', () => {
+  const trendPoints = buildWeightTrendSeries([
+    { id: '1', createdAt: '2026-02-01T08:00:00Z', weight: 70, bodyFatPerc: 21 },
+    { id: '2', createdAt: '2026-02-01T20:00:00Z', weight: 69.8, bodyFatPerc: 20.5 },
+  ])
+
+  const plot = buildTrendCoordinates(trendPoints, {
+    width: 100,
+    height: 80,
+    padding: 10,
+  })
+
+  assert.deepEqual(plot.points.map((point) => point.x), [50, 50])
+})
+
 test('trend series filters non-finite weights and handles a single point', () => {
   const measurements = [
     { id: 'bad', createdAt: '2026-02-01T00:00:00Z', weight: Number.NaN, bodyFatPerc: 21 },

--- a/webapp/tests/dashboard-overhaul.test.mjs
+++ b/webapp/tests/dashboard-overhaul.test.mjs
@@ -13,10 +13,10 @@ import {
 
 test('trend helpers sort weights by date and trim to recent points', () => {
   const measurements = [
-    { id: '1', createdAt: '2026-02-01T10:00:00Z', weight: 80, bodyFatPerc: 21 },
-    { id: '2', createdAt: '2026-02-03T10:00:00Z', weight: 79.2, bodyFatPerc: 20.6 },
-    { id: '3', createdAt: '2026-01-30T10:00:00Z', weight: 81, bodyFatPerc: 21.3 },
-    { id: '4', createdAt: '2026-02-02T10:00:00Z', weight: 79.8, bodyFatPerc: 20.9 },
+    { id: '1', createdAt: '2026-02-01', weight: 80, bodyFatPerc: 21 },
+    { id: '2', createdAt: '2026-02-03', weight: 79.2, bodyFatPerc: 20.6 },
+    { id: '3', createdAt: '2026-01-30', weight: 81, bodyFatPerc: 21.3 },
+    { id: '4', createdAt: '2026-02-02', weight: 79.8, bodyFatPerc: 20.9 },
   ]
 
   const trend = buildWeightTrendSeries(measurements, 3)

--- a/webapp/tests/dashboard-overhaul.test.mjs
+++ b/webapp/tests/dashboard-overhaul.test.mjs
@@ -65,7 +65,7 @@ test('trend coordinate mapping spaces measurements by elapsed time', () => {
   assert.deepEqual(plot.points.map((point) => point.x), [10, 20, 90])
 })
 
-test('trend coordinate mapping centres measurements from the same date', () => {
+test('trend coordinate mapping reflects elapsed time even within the same day', () => {
   const trendPoints = buildWeightTrendSeries([
     { id: '1', createdAt: '2026-02-01T08:00:00Z', weight: 70, bodyFatPerc: 21 },
     { id: '2', createdAt: '2026-02-01T20:00:00Z', weight: 69.8, bodyFatPerc: 20.5 },
@@ -77,7 +77,19 @@ test('trend coordinate mapping centres measurements from the same date', () => {
     padding: 10,
   })
 
-  assert.deepEqual(plot.points.map((point) => point.x), [50, 50])
+  assert.deepEqual(plot.points.map((point) => point.x), [10, 90])
+})
+
+test('trend helpers filter by inclusive date ranges and avoid truncating by default', () => {
+  const points = buildWeightTrendSeries([
+    { id: '1', createdAt: '2026-02-01T00:00:00Z', weight: 70.2, bodyFatPerc: 21 },
+    { id: '2', createdAt: '2026-02-02T00:00:00Z', weight: 70.1, bodyFatPerc: 20.5 },
+    { id: '3', createdAt: '2026-02-03T00:00:00Z', weight: 70, bodyFatPerc: 20.4 },
+  ], undefined, { startDate: '2026-02-01', endDate: '2026-02-02' })
+
+  assert.deepEqual(points.map((point) => point.id), ['1', '2'])
+  assert.deepEqual(points[0].date, '2026-02-01')
+  assert.deepEqual(points[1].date, '2026-02-02')
 })
 
 test('trend series filters non-finite weights and handles a single point', () => {
@@ -137,6 +149,10 @@ test('dashboard query and actions include required data shape and remove hydrati
     new URL('../src/components/Dashboard.tsx', import.meta.url),
     'utf8',
   )
+  const trendChartSource = await readFile(
+    new URL('../src/components/WeightTrendChart.tsx', import.meta.url),
+    'utf8',
+  )
 
   assert.match(dashboardSource, /DASHBOARD_QUERY/)
   assert.match(dashboardSource, /latestWeight/)
@@ -152,8 +168,8 @@ test('dashboard query and actions include required data shape and remove hydrati
   assert.match(dashboardSource, /Log a meal/i)
   assert.match(dashboardSource, /role="progressbar"/)
   assert.match(dashboardSource, /aria-valuetext=/)
-  assert.match(dashboardSource, /key=\{point\.id\}/)
-  assert.match(dashboardSource, /flex justify-between text-xs text-slate-400/)
+  assert.match(trendChartSource, /key=\{point\.id\}/)
+  assert.match(trendChartSource, /flex justify-between text-xs text-slate-400/)
   assert.match(dashboardSource, /millisecondsUntilNextLocalDay/)
   assert.match(dashboardSource, /visibilitychange/)
   assert.match(dashboardSource, /requestSequence/)


### PR DESCRIPTION
## Summary
- add selectable last-month, last-quarter, last-year, and custom weight trend ranges on the measurements page
- share the weight trend chart with the dashboard and plot measurements by real elapsed time
- validate inclusive custom ranges accessibly, refresh preset boundaries at local midnight, and reject malformed measurement dates
- retain the measurements table and its existing add/edit/delete flows

## Verification
- `npm test` — 184 tests passed; exact 100% statements, branches, functions, and lines
- `npm run lint`
- `npm run build`
- focused weight-chart suites under `America/Los_Angeles` and `Pacific/Kiritimati` — 41 tests passed in each timezone
- four fresh read-only local review cycles; final cycle verified clean

## Review
All findings from the first three local review cycles were addressed. A fresh fourth reviewer verified the final immutable head with no actionable findings.
