### PR TITLE
fix(auth): extend login sessions to one week

### DIFF
--- a/backend/config/schema.py
+++ b/backend/config/schema.py
@@ -246,7 +246,7 @@ class Mutation(
             token = jwt.encode(
                 {
                     "sub": str(user.id),
-                    "exp": datetime.now(timezone.utc) + timedelta(days=1),
+                    "exp": datetime.now(timezone.utc) + timedelta(days=7),
                 },
                 settings.SECRET_KEY,
                 algorithm="HS256",

--- a/backend/tests/config/test_schema.py
+++ b/backend/tests/config/test_schema.py
@@ -76,6 +76,40 @@ def test_login_exposes_staff_capability(is_staff):
 
 
 @pytest.mark.django_db
+def test_login_token_expires_after_one_week():
+    """Login issues a backend token that remains valid for one week."""
+    email = "week-token@example.com"
+    password = secrets.token_urlsafe(24)
+    User.objects.create_user(
+        email=email,
+        password=password,
+        date_of_birth="2000-01-01",
+        height=170.0,
+    )
+    issued_after = datetime.now(timezone.utc)
+
+    result = schema.execute_sync(
+        """
+        mutation Login($email: String!, $password: String!) {
+            login(email: $email, password: $password) { token }
+        }
+        """,
+        variable_values={"email": email, "password": password},
+    )
+
+    issued_before = datetime.now(timezone.utc)
+    assert result.errors is None
+    payload = jwt.decode(
+        result.data["login"]["token"],
+        settings.SECRET_KEY,
+        algorithms=["HS256"],
+    )
+    expires_at = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+    assert issued_after + timedelta(days=7, seconds=-1) <= expires_at
+    assert expires_at <= issued_before + timedelta(days=7)
+
+
+@pytest.mark.django_db
 def test_graphql_http_view_executes_login(client):
     """Test the configured HTTP view can execute authentication resolvers."""
     email = "http-login@example.com"

--- a/webapp/src/app/api/auth/[...nextauth]/route.ts
+++ b/webapp/src/app/api/auth/[...nextauth]/route.ts
@@ -27,10 +27,10 @@ const jwtCapabilityCallback = createJwtCapabilityCallback((accessToken) =>
 
 export const authOptions: NextAuthOptions = {
     session: {
-        maxAge: 24 * 60 * 60,
+        maxAge: 7 * 24 * 60 * 60,
     },
     jwt: {
-        maxAge: 24 * 60 * 60,
+        maxAge: 7 * 24 * 60 * 60,
     },
     providers: [
         CredentialsProvider({

--- a/webapp/tests/auth-route-runtime.test.mjs
+++ b/webapp/tests/auth-route-runtime.test.mjs
@@ -43,8 +43,8 @@ test('NextAuth route wires credentials, capability refresh, sessions, handlers, 
   assert.equal(clients[0].endpoint, 'http://localhost:8000/graphql/')
   assert.equal(defaultRoute.GET, handler)
   assert.equal(defaultRoute.POST, handler)
-  assert.equal(defaultRoute.authOptions.session.maxAge, 24 * 60 * 60)
-  assert.equal(defaultRoute.authOptions.jwt.maxAge, 24 * 60 * 60)
+  assert.equal(defaultRoute.authOptions.session.maxAge, 7 * 24 * 60 * 60)
+  assert.equal(defaultRoute.authOptions.jwt.maxAge, 7 * 24 * 60 * 60)
   assert.equal(defaultRoute.authOptions.pages.signIn, '/login')
 
   const provider = defaultRoute.authOptions.providers[0]


### PR DESCRIPTION
## Summary
- extend the frontend NextAuth session and JWT lifetime from 24 hours to 7 days
- extend the backend access-token lifetime to the same 7-day period
- add regression coverage for both frontend and backend expiration settings

## Security
- this deliberately increases the window in which a stolen token could be used from 1 day to 7 days
- existing signed-token validation and secure production cookie settings remain unchanged
- frontend and backend lifetimes stay aligned, avoiding a frontend session that outlives its backend credential
- no refresh token or long-lived secondary credential is introduced

## Test plan
- [x] backend suite: 1,133 passed, 21 skipped, 100% coverage
- [x] frontend suite: 178 passed, exact 100% coverage
- [x] frontend TypeScript check
- [x] frontend lint
- [x] touched backend Black, Flake8, mypy, Pylint, and pydocstyle checks
- [x] `git diff --check`
- [x] changed-line deployment-identifier scan
