### PR TITLE
fix(ci): restore DB restore on preview deployments

### DIFF
--- a/.circleci/scripts/clone_preview_secrets.py
+++ b/.circleci/scripts/clone_preview_secrets.py
@@ -9,7 +9,7 @@ import time
 import click
 from sanitise_branch import sanitise_branch_name
 
-SECRET_SCHEMA = {
+GENERATED_SECRET_SCHEMA = {
     "nutrition-webapp-nextauth-secret": {
         "nextauth-secret": lambda: secrets.token_urlsafe(32),
     },
@@ -22,10 +22,15 @@ SECRET_SCHEMA = {
     "nutrition-gemini-api-key": {
         "gemini-api-key": lambda: secrets.token_urlsafe(32),
     },
-    "nutrition-gcp-db-backup-credentials": {
-        "nutrition-gcp-db-backup-credentials.json": lambda: "{}",
-    },
 }
+
+# The db-restore init container pulls a production database snapshot into every
+# preview, so it needs the real GCP backup credentials. Unlike the other preview
+# secrets (which are generated fresh, least-privilege values), this one must be
+# copied from staging or the restore cannot authenticate.
+COPIED_SECRETS = ["nutrition-gcp-db-backup-credentials"]
+SOURCE_NAMESPACE = "nutrition-staging"
+
 NAMESPACE_PREFIX = "nutrition-staging--"
 
 TARGET_SECRET_PREFIX = "nutrition-preview"  # nosec: B105
@@ -59,47 +64,128 @@ def wait_for_namespace(namespace: str, timeout_seconds: int = 300) -> None:
     sys.exit(1)
 
 
+def _secret_exists(secret_name: str, namespace: str) -> bool:
+    """Return True when the secret already exists in the namespace."""
+    res = subprocess.run(
+        ["kubectl", "get", "secret", secret_name, "-n", namespace],
+        capture_output=True,
+        check=False,
+    )  # nosec: B603, B607
+    return res.returncode == 0
+
+
+def _create_generated_secret(
+    secret_name: str,
+    fields: dict,
+    target_namespace: str,
+) -> None:
+    """Apply a freshly generated secret into the target namespace."""
+    secret_data = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": secret_name,
+            "namespace": target_namespace,
+            "labels": {
+                "app.kubernetes.io/managed-by": TARGET_SECRET_PREFIX,
+            },
+        },
+        "type": "Opaque",
+        "stringData": {key: generator() for key, generator in fields.items()},
+    }
+
+    subprocess.run(
+        ["kubectl", "apply", "-n", target_namespace, "-f", "-"],
+        input=json.dumps(secret_data).encode("utf-8"),
+        check=True,
+    )  # nosec: B603, B607
+
+
+def _copy_secret_from_source(secret_name: str, target_namespace: str) -> None:
+    """Copy an existing secret's payload from the source namespace.
+
+    The copy keeps only the secret's data payload and re-labels it as preview
+    managed, discarding source metadata such as resourceVersion, owner
+    references, and last-applied annotations.
+    """
+    res = subprocess.run(
+        [
+            "kubectl",
+            "get",
+            "secret",
+            secret_name,
+            "-n",
+            SOURCE_NAMESPACE,
+            "-o",
+            "json",
+        ],
+        capture_output=True,
+        check=True,
+    )  # nosec: B603, B607
+    source = json.loads(res.stdout)
+
+    secret_data = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": secret_name,
+            "namespace": target_namespace,
+            "labels": {
+                "app.kubernetes.io/managed-by": TARGET_SECRET_PREFIX,
+            },
+        },
+        "type": source.get("type", "Opaque"),
+        "data": source.get("data", {}),
+    }
+
+    subprocess.run(
+        ["kubectl", "apply", "-n", target_namespace, "-f", "-"],
+        input=json.dumps(secret_data).encode("utf-8"),
+        check=True,
+    )  # nosec: B603, B607
+
+
 def clone_secrets(target_namespace: str) -> None:
-    """Create the required preview secrets directly in the target namespace.
+    """Create preview secrets directly in the target namespace.
+
+    Generated secrets are created with fresh random values; backup-credential
+    secrets are copied from the source namespace. Both are create-if-absent so a
+    re-deploy never rotates values under a running workload.
 
     Args:
         target_namespace (str): The namespace to clone secrets to.
     """
-    for secret_name, fields in SECRET_SCHEMA.items():
-        exists = subprocess.run(
-            ["kubectl", "get", "secret", secret_name, "-n", target_namespace],
-            capture_output=True,
-            check=False,
-        )  # nosec: B603, B607
-        if exists.returncode == 0:
+    for secret_name, fields in GENERATED_SECRET_SCHEMA.items():
+        if _secret_exists(secret_name, target_namespace):
             click.echo(f"Secret {secret_name} already exists. Skipping.")
             continue
         click.echo(f"Creating least-privilege preview secret {secret_name}...")
         try:
-            secret_data = {
-                "apiVersion": "v1",
-                "kind": "Secret",
-                "metadata": {
-                    "name": secret_name,
-                    "namespace": target_namespace,
-                    "labels": {
-                        "app.kubernetes.io/managed-by": TARGET_SECRET_PREFIX,
-                    },
-                },
-                "type": "Opaque",
-                "stringData": {
-                    key: generator() for key, generator in fields.items()
-                },
-            }
-
-            subprocess.run(
-                ["kubectl", "apply", "-n", target_namespace, "-f", "-"],
-                input=json.dumps(secret_data).encode("utf-8"),
-                check=True,
-            )  # nosec: B603, B607
+            _create_generated_secret(secret_name, fields, target_namespace)
         except (OSError, subprocess.CalledProcessError) as e:
             click.echo(
                 f"Error creating secret {secret_name}: {e}",
+                err=True,
+            )
+            sys.exit(1)
+
+    for secret_name in COPIED_SECRETS:
+        if _secret_exists(secret_name, target_namespace):
+            click.echo(f"Secret {secret_name} already exists. Skipping.")
+            continue
+        click.echo(
+            f"Copying {secret_name} from {SOURCE_NAMESPACE} "
+            f"to {target_namespace}..."
+        )
+        try:
+            _copy_secret_from_source(secret_name, target_namespace)
+        except (
+            OSError,
+            subprocess.CalledProcessError,
+            json.JSONDecodeError,
+        ) as e:
+            click.echo(
+                f"Error copying secret {secret_name}: {e}",
                 err=True,
             )
             sys.exit(1)

--- a/.circleci/scripts/generate_flux_preview.py
+++ b/.circleci/scripts/generate_flux_preview.py
@@ -172,11 +172,6 @@ spec:
                       value: "{preview_host}"
                     - name: CSRF_TRUSTED_ORIGINS
                       value: "https://{preview_host}"
-              initContainers:
-                - name: db-restore
-                  env:
-                    - name: SKIP_DB_RESTORE
-                      value: "true"
       target:
         kind: Deployment
         name: nutrition-backend

--- a/.circleci/scripts/test_clone_secrets.py
+++ b/.circleci/scripts/test_clone_secrets.py
@@ -1,5 +1,6 @@
 """Tests for the clone_preview_secrets script."""
 
+import base64
 import json
 from subprocess import CompletedProcess
 from typing import Any
@@ -9,6 +10,24 @@ from click.testing import CliRunner
 from clone_preview_secrets import main
 from sanitise_branch import sanitise_branch_name
 
+GCP_SOURCE_SECRET = {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {
+        "name": "nutrition-gcp-db-backup-credentials",
+        "namespace": "nutrition-staging",
+        "uid": "staging-uid",
+        "resourceVersion": "12345",
+        "creationTimestamp": "2026-01-01T00:00:00Z",
+    },
+    "type": "Opaque",
+    "data": {
+        "nutrition-gcp-db-backup-credentials.json": base64.b64encode(
+            b'{"client_email": "backup@example.com", "private_key": "key"}'
+        ).decode("utf-8"),
+    },
+}
+
 
 @pytest.fixture
 def mock_run(mocker):
@@ -17,11 +36,32 @@ def mock_run(mocker):
 
 
 def _fake_kubectl(*args, **kwargs):
-    """Return NotFound for secret existence checks so secrets get created."""
+    """Return NotFound for preview existence checks, source JSON for the copy."""
     cmd = args[0]
     if cmd[:3] == ["kubectl", "get", "secret"]:
+        # Read from staging is the backup-credentials copy source.
+        if (
+            cmd[3] == "nutrition-gcp-db-backup-credentials"
+            and cmd[5] == "nutrition-staging"
+        ):
+            return CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout=json.dumps(GCP_SOURCE_SECRET).encode("utf-8"),
+                stderr=b"",
+            )
+        # Any other secret read is a create-if-absent existence check: NotFound.
         return CompletedProcess(args=cmd, returncode=1, stdout=b"", stderr=b"")
     return CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+
+def _apply_calls(mock_run, expected_ns: str) -> list:
+    return [
+        call
+        for call in mock_run.call_args_list
+        if call.args[0][0:3] == ["kubectl", "apply", "-n"]
+        and call.args[0][3] == expected_ns
+    ]
 
 
 def test_main_skip_main_branch(mock_run):
@@ -36,10 +76,9 @@ def test_main_skip_main_branch(mock_run):
 
 
 def test_main_success(mock_run, mocker):
-    """Test successful preview credential creation."""
+    """Test that generated secrets are created and the backup creds copied."""
     runner = CliRunner()
     mocker.patch("time.sleep")
-
     mock_run.side_effect = _fake_kubectl
 
     result = runner.invoke(main, ["feature/test-branch"])
@@ -49,123 +88,134 @@ def test_main_success(mock_run, mocker):
         f"nutrition-staging--{sanitise_branch_name('feature/test-branch')}"
     )
     assert f"Waiting for namespace {expected_ns} to exist..." in result.output
+    for generated in [
+        "nutrition-webapp-nextauth-secret",
+        "nutrition-postgresql",
+        "nutrition-django-secret-key",
+        "nutrition-gemini-api-key",
+    ]:
+        assert (
+            f"Creating least-privilege preview secret {generated}..."
+        ) in result.output
     assert (
-        "Creating least-privilege preview secret nutrition-webapp-nextauth-secret..."
+        f"Copying nutrition-gcp-db-backup-credentials from nutrition-staging "
+        f"to {expected_ns}..."
     ) in result.output
-    assert (
-        "Creating least-privilege preview secret nutrition-postgresql..."
-    ) in result.output
-    assert (
-        "Creating least-privilege preview secret nutrition-gemini-api-key..."
-    ) in result.output
-    assert mock_run.call_count == 11
 
-    # Secrets are created directly in the target namespace and never read from
-    # staging.
-    assert not any(
-        call.args[0][:2] == ["kubectl", "get"]
-        and call.args[0][3] == "-n"
-        and call.args[0][4] == "nutrition-staging"
+    # The only staging read is the backup-credentials copy; the four generated
+    # secrets never read from staging.
+    staging_reads = [
+        call.args[0]
         for call in mock_run.call_args_list
-    )
+        if call.args[0][:2] == ["kubectl", "get"]
+        and "-n" in call.args[0]
+        and call.args[0][-1] != expected_ns
+        and call.args[0][call.args[0].index("-n") + 1] == "nutrition-staging"
+    ]
+    assert staging_reads == [
+        [
+            "kubectl",
+            "get",
+            "secret",
+            "nutrition-gcp-db-backup-credentials",
+            "-n",
+            "nutrition-staging",
+            "-o",
+            "json",
+        ]
+    ]
 
 
 def test_main_apply_payload(mock_run, mocker):
-    """Test that each generated secret contains expected preview keys."""
+    """Test that each preview secret is applied with the expected shape."""
     runner = CliRunner()
     mocker.patch("time.sleep")
-
     mock_run.side_effect = _fake_kubectl
 
     runner.invoke(main, ["feature/test"])
 
     expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test')}"
-    apply_calls = [
-        call
-        for call in mock_run.call_args_list
-        if call.args[0][0:3] == ["kubectl", "apply", "-n"]
-        and call.args[0][3] == expected_ns
-    ]
+    apply_calls = _apply_calls(mock_run, expected_ns)
     assert len(apply_calls) == 5
 
+    generated_seen = 0
+    copied_seen = 0
     for call in apply_calls:
-        payload = json.loads(call.kwargs["input"].decode("utf-8"))
+        payload: dict[str, Any] = json.loads(
+            call.kwargs["input"].decode("utf-8")
+        )
         assert payload["kind"] == "Secret"
         assert payload["type"] == "Opaque"
         assert (
             payload["metadata"]["labels"]["app.kubernetes.io/managed-by"]
             == "nutrition-preview"
         )
+        assert payload["metadata"]["namespace"] == expected_ns
+        if (
+            payload["metadata"]["name"]
+            == "nutrition-gcp-db-backup-credentials"
+        ):
+            # The copied secret carries the source data payload, not a stub.
+            assert "stringData" not in payload
+            assert payload["data"] == GCP_SOURCE_SECRET["data"]
+            copied_seen += 1
+        else:
+            assert "stringData" in payload
+            assert "data" not in payload
+            generated_seen += 1
+
+    assert generated_seen == 4
+    assert copied_seen == 1
 
 
-def test_main_does_not_read_staging_credentials(mock_run, mocker):
-    """Test that preview secret creation does not read source staging secrets."""
+def test_main_generated_secrets_do_not_read_staging(mock_run, mocker):
+    """Test that generated secrets are never sourced from staging."""
     runner = CliRunner()
     mocker.patch("time.sleep")
-
     mock_run.side_effect = _fake_kubectl
 
     result = runner.invoke(main, ["feature/test"])
-    expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test')}"
 
     assert result.exit_code == 0
-    assert all(
-        call.args[0] == ["kubectl", "get", "namespace", expected_ns]
-        or (
-            call.args[0][:3] == ["kubectl", "get", "secret"]
-            and call.args[0][-2:] == ["-n", expected_ns]
-        )
-        for call in mock_run.call_args_list
-        if call.args[0][:2] == ["kubectl", "get"]
-    )
 
-    non_staging_read_attempts = [
+    # Every staging-namespace secret read must be for the backup credentials.
+    staging_secret_reads = [
         call.args[0]
         for call in mock_run.call_args_list
-        if call.args[0][:2] == ["kubectl", "get"]
-        and "-n" in call.args[0]
-        and call.args[0][-2:] != ["-n", expected_ns]
+        if call.args[0][:3] == ["kubectl", "get", "secret"]
+        and call.args[0][5] == "nutrition-staging"
     ]
-    assert not non_staging_read_attempts
+    assert len(staging_secret_reads) == 1
+    assert staging_secret_reads[0][3] == "nutrition-gcp-db-backup-credentials"
 
 
 def test_main_secrets_are_preview_scoped_and_non_empty(mock_run, mocker):
-    """Test that each required preview secret uses generated values."""
+    """Test generated secret values are fresh and never empty/stubbed."""
     runner = CliRunner()
     mocker.patch("time.sleep")
-    generated_tokens = [
-        "token-1",
-        "token-2",
-        "token-3",
-        "token-4",
-    ]
+    generated_tokens = ["token-1", "token-2", "token-3", "token-4"]
     mocker.patch(
         "clone_preview_secrets.secrets.token_urlsafe",
         side_effect=lambda _n: generated_tokens.pop(0),
     )
-
     mock_run.side_effect = _fake_kubectl
 
     result = runner.invoke(main, ["feature/test"])
     expected_ns = f"nutrition-staging--{sanitise_branch_name('feature/test')}"
 
     assert result.exit_code == 0
-    apply_calls = [
-        call
-        for call in mock_run.call_args_list
-        if call.args[0][0:3] == ["kubectl", "apply", "-n"]
-        and call.args[0][3] == expected_ns
-    ]
+    apply_calls = _apply_calls(mock_run, expected_ns)
     assert len(apply_calls) == 5
 
-    seen_values: list[str] = []
+    generated_values: list[str] = []
     for call in apply_calls:
         payload: dict[str, Any] = json.loads(
             call.kwargs["input"].decode("utf-8")
         )
-        secrets_payload = payload["stringData"]
-        assert secrets_payload
-        seen_values.extend(secrets_payload.values())
-    assert sorted(seen_values) == sorted(
-        ["token-1", "token-2", "token-3", "token-4", "{}"]
+        if "stringData" in payload:
+            assert payload["stringData"]
+            generated_values.extend(payload["stringData"].values())
+
+    assert sorted(generated_values) == sorted(
+        ["token-1", "token-2", "token-3", "token-4"]
     )

--- a/.circleci/scripts/test_generate_preview.py
+++ b/.circleci/scripts/test_generate_preview.py
@@ -120,13 +120,9 @@ def test_generate_manifest_content():
     assert f"targetNamespace: nutrition-staging--{sanitized}" in manifest
     assert f"serviceAccountName: nutrition-preview-sa-{sanitized}" in manifest
     assert f"name: source-{sanitized}" in manifest
-    assert "name: SKIP_DB_RESTORE" in manifest
-    assert 'value: "true"' in manifest
+    assert "name: SKIP_DB_RESTORE" not in manifest
+    assert "initContainers:" not in manifest
     assert 'value: "https://custom.example.com"' in manifest
-    assert re.search(
-        r"initContainers:\n\s*- name: db-restore\n\s*env:\n\s*- name: SKIP_DB_RESTORE",
-        manifest,
-    )
     assert "newTag: v1.0.0" in manifest
     assert "value: custom.example.com" in manifest
 
@@ -186,7 +182,7 @@ def test_main_dry_run(mock_check_output):
         f"serviceAccountName: nutrition-preview-sa-{sanitized}"
         in result.output
     )
-    assert "SKIP_DB_RESTORE" in result.output
+    assert "SKIP_DB_RESTORE" not in result.output
     assert "kind: ServiceAccount" in result.output
     assert "kind: Role" in result.output
     assert "kind: RoleBinding" in result.output


### PR DESCRIPTION
## Summary

Preview deployments stopped syncing the database, so every new preview came up empty (no accounts, no data) and the owner could not log in.

Root cause: two prior hardening commits disabled the restore:

- `b2accb1` changed the preview secret step from *copying staging's secrets* to *generating fresh random values*, and stubbed `nutrition-gcp-db-backup-credentials` to `"{}"`.
- `49d114a` added `SKIP_DB_RESTORE: "true"` to the preview backend.

Together those made the `db-restore` init container skip the restore on every preview deploy.

## Change

- **`generate_flux_preview.py`** — remove the `SKIP_DB_RESTORE=true` override so the `db-restore` init container runs its normal restore path again.
- **`clone_preview_secrets.py`** — copy the real `nutrition-gcp-db-backup-credentials` from `nutrition-staging` into the preview namespace (create-if-absent), while keeping the other preview secrets freshly generated. The copied secret keeps only its data payload and is re-labelled `app.kubernetes.io/managed-by: nutrition-preview`.
- Tests updated to assert the restored behaviour (no `SKIP_DB_RESTORE` in the generated manifest; backup creds copied, not stubbed; generated secrets never read from staging).

## Verification

- `.circleci/scripts` test suite: **46 passed**
- `black`, `flake8`, `pylint`, `mypy`, `pydocstyle`, `bandit` clean on the changed files
- Staged diff scanned clean for deployment identifiers; `git diff --check` clean
